### PR TITLE
Accountfilters

### DIFF
--- a/cmd/moncli/cmd/accounts.go
+++ b/cmd/moncli/cmd/accounts.go
@@ -49,9 +49,9 @@ var accountsCmd = &cobra.Command{
 			return errors.Wrap(err, "selecting accounts")
 		}
 
-		fs, err := prepareFilters()
+		fs, err := prepareConditions()
 		if err != nil {
-			return errors.Wrap(err, "preparing filters")
+			return errors.Wrap(err, "preparing conditions")
 		}
 
 		for _, f := range fs {
@@ -110,8 +110,8 @@ var accountsCmd = &cobra.Command{
 	},
 }
 
-func prepareFilters() ([]filter.AccountFilter, error) {
-	fs := []filter.AccountFilter{
+func prepareConditions() ([]filter.AccountCondition, error) {
+	fs := []filter.AccountCondition{
 		filter.Existed(*atDate.Time),
 	}
 
@@ -120,7 +120,7 @@ func prepareFilters() ([]filter.AccountFilter, error) {
 	}
 
 	if len(ids) > 0 {
-		var idf filter.AccountFilters
+		var idf filter.AccountConditions
 		for _, id := range ids {
 			idf = append(idf, filter.ID(id))
 		}
@@ -132,7 +132,7 @@ func prepareFilters() ([]filter.AccountFilter, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "converting currency string to currency codes")
 		}
-		var cf filter.AccountFilters
+		var cf filter.AccountConditions
 		for _, c := range cs {
 			cf = append(cf, filter.Currency(c))
 		}

--- a/cmd/moncli/cmd/accounts.go
+++ b/cmd/moncli/cmd/accounts.go
@@ -49,14 +49,12 @@ var accountsCmd = &cobra.Command{
 			return errors.Wrap(err, "selecting accounts")
 		}
 
-		fs, err := prepareConditions()
+		cs, err := prepareConditions()
 		if err != nil {
 			return errors.Wrap(err, "preparing conditions")
 		}
 
-		for _, f := range fs {
-			*as = filter.Filter(*as, f)
-		}
+		*as = filter.AccountCondition(cs.And).Filter(*as)
 
 		if viper.GetBool(keyQuiet) {
 			for _, a := range *as {

--- a/cmd/moncli/cmd/accounts.go
+++ b/cmd/moncli/cmd/accounts.go
@@ -120,7 +120,11 @@ func prepareFilters() ([]filter.AccountFilter, error) {
 	}
 
 	if len(ids) > 0 {
-		fs = append(fs, filter.IDs(ids))
+		var idf filter.AccountFilters
+		for _, id := range ids {
+			idf = append(idf, filter.ID(id))
+		}
+		fs = append(fs, idf.Or)
 	}
 
 	if len(currencies) > 0 {
@@ -128,7 +132,11 @@ func prepareFilters() ([]filter.AccountFilter, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "converting currency string to currency codes")
 		}
-		fs = append(fs, filter.Currencies(cs...))
+		var cf filter.AccountFilters
+		for _, c := range cs {
+			cf = append(cf, filter.Currency(c))
+		}
+		fs = append(fs, cf.Or)
 	}
 
 	return fs, nil

--- a/cmd/moncli/cmd/accounts.go
+++ b/cmd/moncli/cmd/accounts.go
@@ -49,12 +49,12 @@ var accountsCmd = &cobra.Command{
 			return errors.Wrap(err, "selecting accounts")
 		}
 
-		cs, err := prepareConditions()
+		ac, err := prepareCondition()
 		if err != nil {
 			return errors.Wrap(err, "preparing conditions")
 		}
 
-		*as = filter.AccountCondition(cs.And).Filter(*as)
+		*as = ac.Filter(*as)
 
 		if viper.GetBool(keyQuiet) {
 			for _, a := range *as {
@@ -108,49 +108,49 @@ var accountsCmd = &cobra.Command{
 	},
 }
 
-func prepareConditions() (filter.AccountConditions, error) {
-	fs := []filter.AccountCondition{
+func prepareCondition() (filter.AccountCondition, error) {
+	cs := filter.AccountConditions{
 		filter.Existed(*atDate.Time),
 	}
 
 	if viper.GetBool(keyOpen) {
-		fs = append(fs, filter.OpenAt(*atDate.Time))
+		cs = append(cs, filter.OpenAt(*atDate.Time))
 	}
 
 	if len(ids) > 0 {
-		var idf filter.AccountConditions
-		for _, id := range ids {
-			idf = append(idf, filter.ID(id))
-		}
-		fs = append(fs, idf.Or)
+		cs = append(cs, idsCondition(ids))
 	}
 
 	if len(currencies) > 0 {
-		cs, err := currencyStringsToCodes(currencies...)
+		ccs, err := currenciesCondition(currencies)
 		if err != nil {
-			return nil, errors.Wrap(err, "converting currency string to currency codes")
+			return nil, errors.Wrap(err, "creating currencies condition")
 		}
-		var cf filter.AccountConditions
-		for _, c := range cs {
-			cf = append(cf, filter.Currency(c))
-		}
-		fs = append(fs, cf.Or)
+		cs = append(cs, ccs)
 	}
 
-	return fs, nil
+	// Account must meet all AccountConditions
+	return cs.And, nil
 }
 
-func init() {
-	rootCmd.AddCommand(accountsCmd)
-	accountsCmd.Flags().BoolP(keyOpen, "", false, "show only open accounts")
-	accountsCmd.Flags().UintSliceVar(&ids, keyIDs, []uint{}, "filter by ids")
-	accountsCmd.Flags().StringSliceVar(&currencies, keyCurrencies, []string{}, "filter by currencies")
-	accountsCmd.Flags().BoolP(keyQuiet, "q", false, "show only account ids")
-	accountsCmd.Flags().BoolP(keyBalances, "b", false, "show balances for each account")
-	accountsCmd.Flags().Var(atDate, keyAtDate, "show balances at a certain date")
-	if err := viper.BindPFlags(accountsCmd.Flags()); err != nil {
-		log.Fatal(errors.Wrap(err, "binding pflags"))
+func idsCondition(ids []uint) filter.AccountCondition {
+	var cs filter.AccountConditions
+	for _, id := range ids {
+		cs = append(cs, filter.ID(id))
 	}
+	return cs.Or
+}
+
+func currenciesCondition(cs []string) (filter.AccountCondition, error) {
+	ccs, err := currencyStringsToCodes(cs...)
+	if err != nil {
+		return nil, errors.Wrap(err, "converting currency string to currency codes")
+	}
+	var acs filter.AccountConditions
+	for _, c := range ccs {
+		acs = append(acs, filter.Currency(c))
+	}
+	return acs.Or, nil
 }
 
 // TODO: this should be handled as a flags type perhaps?
@@ -164,4 +164,17 @@ func currencyStringsToCodes(css ...string) ([]currency.Code, error) {
 		codes = append(codes, *c)
 	}
 	return codes, nil
+}
+
+func init() {
+	rootCmd.AddCommand(accountsCmd)
+	accountsCmd.Flags().Bool(keyOpen, false, "show only open accounts")
+	accountsCmd.Flags().UintSliceVar(&ids, keyIDs, []uint{}, "filter by ids")
+	accountsCmd.Flags().StringSliceVar(&currencies, keyCurrencies, []string{}, "filter by currencies")
+	accountsCmd.Flags().BoolP(keyQuiet, "q", false, "show only account ids")
+	accountsCmd.Flags().BoolP(keyBalances, "b", false, "show balances for each account")
+	accountsCmd.Flags().Var(atDate, keyAtDate, "show balances at a certain date")
+	if err := viper.BindPFlags(accountsCmd.Flags()); err != nil {
+		log.Fatal(errors.Wrap(err, "binding pflags"))
+	}
 }

--- a/cmd/moncli/cmd/accounts.go
+++ b/cmd/moncli/cmd/accounts.go
@@ -110,7 +110,7 @@ var accountsCmd = &cobra.Command{
 	},
 }
 
-func prepareConditions() ([]filter.AccountCondition, error) {
+func prepareConditions() (filter.AccountConditions, error) {
 	fs := []filter.AccountCondition{
 		filter.Existed(*atDate.Time),
 	}

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -12,10 +12,18 @@ import (
 type AccountFilter func(storage.Account) bool
 
 // Existed produces an AccountFilter that can be used to identify if an
-// Account existed at a given time
+// Account existed/exists/will-exist at a given time
 func Existed(t time.Time) AccountFilter {
 	return func(a storage.Account) bool {
 		return !a.Account.Opened().After(t)
+	}
+}
+
+// OpenAt produces an AccountFilter that will identify if a storage.Account
+// was/is/will-be open at a given time
+func OpenAt(t time.Time) AccountFilter {
+	return func(a storage.Account) bool {
+		return a.Account.OpenAt(t)
 	}
 }
 
@@ -32,14 +40,6 @@ func Currency(c currency.Code) AccountFilter {
 func ID(id uint) AccountFilter {
 	return func(a storage.Account) bool {
 		return a.ID == id
-	}
-}
-
-// OpenAt produces an AccountFilter that will identify if a storage.Account
-// was/is/will-be open at a given time
-func OpenAt(t time.Time) AccountFilter {
-	return func(a storage.Account) bool {
-		return a.Account.OpenAt(t)
 	}
 }
 

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -11,6 +11,18 @@ import (
 // satisfies some certain condition.
 type AccountCondition func(storage.Account) bool
 
+// Filter returns a set of storage.Accounts that have been filtered down to the
+// ones that match the AccountCondition
+func (ac AccountCondition) Filter(as storage.Accounts) storage.Accounts {
+	var filtered []storage.Account
+	for _, a := range as {
+		if ac(a) {
+			filtered = append(filtered, a)
+		}
+	}
+	return storage.Accounts(filtered)
+}
+
 // Existed produces an AccountCondition that can be used to identify if an
 // Account existed/exists/will-exist at a given time.
 // Existed will identify that an Account existed if its open date matches or
@@ -57,4 +69,16 @@ func (acs AccountConditions) Or(a storage.Account) bool {
 		}
 	}
 	return false
+}
+
+// And identifies when an account satisfies every AccountCondition of an
+// AccountConditions.
+// When no AccountConditions are present, the storage.Account will always match
+func (acs AccountConditions) And(a storage.Account) bool {
+	for _, ac := range acs {
+		if !ac(a) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -13,6 +13,8 @@ type AccountFilter func(storage.Account) bool
 
 // Existed produces an AccountFilter that can be used to identify if an
 // Account existed/exists/will-exist at a given time
+// Existed will identify that an Account existed if its open date matches or
+// was before the given time.
 func Existed(t time.Time) AccountFilter {
 	return func(a storage.Account) bool {
 		return !a.Account.Opened().After(t)

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -50,22 +50,11 @@ type AccountConditions []AccountCondition
 
 // Or identifies when an account satisfies one of more constraints of an
 // AccountConditions
-func (afs AccountConditions) Or(a storage.Account) bool {
-	for _, af := range afs {
-		if af(a) {
+func (acs AccountConditions) Or(a storage.Account) bool {
+	for _, ac := range acs {
+		if ac(a) {
 			return true
 		}
 	}
 	return false
-}
-
-// Filter returns a set of storage.Accounts that match the given AccountCondition
-func Filter(as storage.Accounts, f AccountCondition) storage.Accounts {
-	var filtered []storage.Account
-	for _, a := range as {
-		if f(a) {
-			filtered = append(filtered, a)
-		}
-	}
-	return storage.Accounts(filtered)
 }

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -53,6 +53,20 @@ func OpenAt(t time.Time) AccountFilter {
 	}
 }
 
+// AccountFilters is a set of AccountFilter
+type AccountFilters []AccountFilter
+
+// Or identifies when an account satisfies one of more constaints of an
+// AccountFilters
+func (afs AccountFilters) Or(a storage.Account) bool {
+	for _, af := range afs {
+		if af(a) {
+			return true
+		}
+	}
+	return false
+}
+
 // Filter returns a set of storage.Accounts that match the given AccountFilter
 func Filter(as storage.Accounts, f AccountFilter) storage.Accounts {
 	var filtered []storage.Account

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -7,50 +7,50 @@ import (
 	"github.com/glynternet/mon/pkg/storage"
 )
 
-// AccountFilter is a function that will return true if a given storage.Account
-// satisfies some certain criteria.
-type AccountFilter func(storage.Account) bool
+// AccountCondition is a function that will return true if a given storage.Account
+// satisfies some certain condition.
+type AccountCondition func(storage.Account) bool
 
-// Existed produces an AccountFilter that can be used to identify if an
-// Account existed/exists/will-exist at a given time
+// Existed produces an AccountCondition that can be used to identify if an
+// Account existed/exists/will-exist at a given time.
 // Existed will identify that an Account existed if its open date matches or
-// was before the given time.
-func Existed(t time.Time) AccountFilter {
+// was before the given time
+func Existed(t time.Time) AccountCondition {
 	return func(a storage.Account) bool {
 		return !a.Account.Opened().After(t)
 	}
 }
 
-// OpenAt produces an AccountFilter that will identify if a storage.Account
+// OpenAt produces an AccountCondition that will identify if a storage.Account
 // was/is/will-be open at a given time
-func OpenAt(t time.Time) AccountFilter {
+func OpenAt(t time.Time) AccountCondition {
 	return func(a storage.Account) bool {
 		return a.Account.OpenAt(t)
 	}
 }
 
-// Currency produces an AccountFilter that will identify a storage.Account if
+// Currency produces an AccountCondition that will identify a storage.Account if
 // it has a given currency.Code
-func Currency(c currency.Code) AccountFilter {
+func Currency(c currency.Code) AccountCondition {
 	return func(a storage.Account) bool {
 		return a.Account.CurrencyCode() == c
 	}
 }
 
-// ID produces an AccountFilter that will identify a storage.Account if it
+// ID produces an AccountCondition that will identify a storage.Account if it
 // matches an ID
-func ID(id uint) AccountFilter {
+func ID(id uint) AccountCondition {
 	return func(a storage.Account) bool {
 		return a.ID == id
 	}
 }
 
-// AccountFilters is a set of AccountFilter
-type AccountFilters []AccountFilter
+// AccountConditions is a set of AccountCondition
+type AccountConditions []AccountCondition
 
-// Or identifies when an account satisfies one of more constaints of an
-// AccountFilters
-func (afs AccountFilters) Or(a storage.Account) bool {
+// Or identifies when an account satisfies one of more constraints of an
+// AccountConditions
+func (afs AccountConditions) Or(a storage.Account) bool {
 	for _, af := range afs {
 		if af(a) {
 			return true
@@ -59,8 +59,8 @@ func (afs AccountFilters) Or(a storage.Account) bool {
 	return false
 }
 
-// Filter returns a set of storage.Accounts that match the given AccountFilter
-func Filter(as storage.Accounts, f AccountFilter) storage.Accounts {
+// Filter returns a set of storage.Accounts that match the given AccountCondition
+func Filter(as storage.Accounts, f AccountCondition) storage.Accounts {
 	var filtered []storage.Account
 	for _, a := range as {
 		if f(a) {

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -14,7 +14,7 @@ type AccountCondition func(storage.Account) bool
 // Filter returns a set of storage.Accounts that have been filtered down to the
 // ones that match the AccountCondition
 func (ac AccountCondition) Filter(as storage.Accounts) storage.Accounts {
-	var filtered []storage.Account
+	var filtered storage.Accounts
 	for _, a := range as {
 		if ac(a) {
 			filtered = append(filtered, a)

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -19,29 +19,19 @@ func Existed(t time.Time) AccountFilter {
 	}
 }
 
-// Currencies produces an AccountFilter that will identify a storage.Account if
-// it is within a given set of currency codes
-func Currencies(cs ...currency.Code) AccountFilter {
+// Currency produces an AccountFilter that will identify a storage.Account if
+// it has a given currency.Code
+func Currency(c currency.Code) AccountFilter {
 	return func(a storage.Account) bool {
-		for _, c := range cs {
-			if a.Account.CurrencyCode() == c {
-				return true
-			}
-		}
-		return false
+		return a.Account.CurrencyCode() == c
 	}
 }
 
-// IDs produces an AccountFilter that will identify a storage.Account if it
-// matches on of a given set of IDs
-func IDs(ids []uint) AccountFilter {
+// ID produces an AccountFilter that will identify a storage.Account if it
+// matches an ID
+func ID(id uint) AccountFilter {
 	return func(a storage.Account) bool {
-		for _, id := range ids {
-			if a.ID == id {
-				return true
-			}
-		}
-		return false
+		return a.ID == id
 	}
 }
 

--- a/pkg/filter/account_test.go
+++ b/pkg/filter/account_test.go
@@ -1,0 +1,70 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/glynternet/mon/pkg/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func stubFilter(result bool) AccountFilter {
+	return func(_ storage.Account) bool {
+		return result
+	}
+}
+
+func TestAccountFilters_Or(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		AccountFilters
+		storage.Account
+		expected bool
+	}{
+		{
+			name: "zero-values",
+		},
+		{
+			name:     "single filter passing",
+			expected: true,
+			AccountFilters: AccountFilters{
+				stubFilter(true),
+			},
+		},
+		{
+			name: "single filter failing",
+			AccountFilters: AccountFilters{
+				stubFilter(false),
+			},
+		},
+		{
+			name:     "multiple filters passing",
+			expected: true,
+			AccountFilters: AccountFilters{
+				stubFilter(true),
+				stubFilter(true),
+			},
+		},
+		{
+			name: "multiple filters failing",
+			AccountFilters: AccountFilters{
+				stubFilter(false),
+				stubFilter(false),
+			},
+		},
+		{
+			name:     "multiple filters mixed",
+			expected: true,
+			AccountFilters: AccountFilters{
+				stubFilter(false),
+				stubFilter(false),
+				stubFilter(true),
+				stubFilter(false),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.AccountFilters.Or(test.Account)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/pkg/filter/account_test.go
+++ b/pkg/filter/account_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/glynternet/go-accounting/account"
 	"github.com/glynternet/go-accounting/accountingtest"
 	"github.com/glynternet/go-money/currency"
 	"github.com/glynternet/mon/pkg/filter"
@@ -120,6 +121,38 @@ func TestExisted(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := filter.Existed(test.Time)
+			match := f(test.Account)
+			assert.Equal(t, test.match, match)
+		})
+	}
+}
+
+func TestOpenAt(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		storage.Account
+		time.Time
+		match bool
+	}{
+		{
+			name:  "zero-values",
+			match: true,
+		},
+		{
+			name:    "open account",
+			Account: storage.Account{Account: *accountingtest.NewAccount(t, "test", accountingtest.NewCurrencyCode(t, "BUP"), time.Date(1999, 0, 0, 0, 0, 0, 0, time.UTC))},
+			Time:    time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC),
+			match:   true,
+		},
+		{
+			name:    "closed account",
+			Account: storage.Account{Account: *accountingtest.NewAccount(t, "test", accountingtest.NewCurrencyCode(t, "BUP"), time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC), account.CloseTime(time.Date(2001, 0, 0, 0, 0, 0, 0, time.UTC)))},
+			Time:    time.Date(2002, 0, 0, 0, 0, 0, 0, time.UTC),
+			match:   false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := filter.OpenAt(test.Time)
 			match := f(test.Account)
 			assert.Equal(t, test.match, match)
 		})

--- a/pkg/filter/account_test.go
+++ b/pkg/filter/account_test.go
@@ -14,6 +14,37 @@ func stubFilter(result bool) filter.AccountFilter {
 	}
 }
 
+func TestID(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		storage.Account
+		id    uint
+		match bool
+	}{
+		{
+			name:  "zero-values",
+			match: true,
+		},
+		{
+			name:    "matching",
+			Account: storage.Account{ID: 111},
+			id:      111,
+			match:   true,
+		},
+		{
+			name:    "non-matching",
+			Account: storage.Account{ID: 222},
+			id:      123,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := filter.ID(test.id)
+			match := f(test.Account)
+			assert.Equal(t, test.match, match)
+		})
+	}
+}
+
 func TestAccountFilters_Or(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/pkg/filter/account_test.go
+++ b/pkg/filter/account_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func stubFilter(result bool) filter.AccountFilter {
+func stubAccountCondition(match bool) filter.AccountCondition {
 	return func(_ storage.Account) bool {
-		return result
+		return match
 	}
 }
 
@@ -159,10 +159,10 @@ func TestOpenAt(t *testing.T) {
 	}
 }
 
-func TestAccountFilters_Or(t *testing.T) {
+func TestAccountConditions_Or(t *testing.T) {
 	for _, test := range []struct {
 		name string
-		filter.AccountFilters
+		filter.AccountConditions
 		storage.Account
 		expected bool
 	}{
@@ -170,46 +170,46 @@ func TestAccountFilters_Or(t *testing.T) {
 			name: "zero-values",
 		},
 		{
-			name:     "single filter passing",
+			name:     "single condition matching",
 			expected: true,
-			AccountFilters: filter.AccountFilters{
-				stubFilter(true),
+			AccountConditions: filter.AccountConditions{
+				stubAccountCondition(true),
 			},
 		},
 		{
-			name: "single filter failing",
-			AccountFilters: filter.AccountFilters{
-				stubFilter(false),
+			name: "single condition non-matching",
+			AccountConditions: filter.AccountConditions{
+				stubAccountCondition(false),
 			},
 		},
 		{
-			name:     "multiple filters passing",
+			name:     "multiple conditions matching",
 			expected: true,
-			AccountFilters: filter.AccountFilters{
-				stubFilter(true),
-				stubFilter(true),
+			AccountConditions: filter.AccountConditions{
+				stubAccountCondition(true),
+				stubAccountCondition(true),
 			},
 		},
 		{
-			name: "multiple filters failing",
-			AccountFilters: filter.AccountFilters{
-				stubFilter(false),
-				stubFilter(false),
+			name: "multiple conditions non-matching",
+			AccountConditions: filter.AccountConditions{
+				stubAccountCondition(false),
+				stubAccountCondition(false),
 			},
 		},
 		{
-			name:     "multiple filters mixed",
+			name:     "multiple conditions mixed-results",
 			expected: true,
-			AccountFilters: filter.AccountFilters{
-				stubFilter(false),
-				stubFilter(false),
-				stubFilter(true),
-				stubFilter(false),
+			AccountConditions: filter.AccountConditions{
+				stubAccountCondition(false),
+				stubAccountCondition(false),
+				stubAccountCondition(true),
+				stubAccountCondition(false),
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			actual := test.AccountFilters.Or(test.Account)
+			actual := test.AccountConditions.Or(test.Account)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/pkg/filter/account_test.go
+++ b/pkg/filter/account_test.go
@@ -88,6 +88,44 @@ func TestCurrency(t *testing.T) {
 	}
 }
 
+func TestExisted(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		storage.Account
+		time.Time
+		match bool
+	}{
+		{
+			name:  "zero-values",
+			match: true,
+		},
+		{
+			name:    "time before open",
+			Account: storage.Account{Account: *accountingtest.NewAccount(t, "test", accountingtest.NewCurrencyCode(t, "BUP"), time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC))},
+			Time:    time.Date(1999, 0, 0, 0, 0, 0, 0, time.UTC),
+			match:   false,
+		},
+		{
+			name:    "time equal open",
+			Account: storage.Account{Account: *accountingtest.NewAccount(t, "test", accountingtest.NewCurrencyCode(t, "BUP"), time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC))},
+			Time:    time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC),
+			match:   true,
+		},
+		{
+			name:    "time after open",
+			Account: storage.Account{Account: *accountingtest.NewAccount(t, "test", accountingtest.NewCurrencyCode(t, "BUP"), time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC))},
+			Time:    time.Date(2001, 0, 0, 0, 0, 0, 0, time.UTC),
+			match:   true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := filter.Existed(test.Time)
+			match := f(test.Account)
+			assert.Equal(t, test.match, match)
+		})
+	}
+}
+
 func TestAccountFilters_Or(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/pkg/filter/account_test.go
+++ b/pkg/filter/account_test.go
@@ -1,13 +1,14 @@
-package filter
+package filter_test
 
 import (
 	"testing"
 
+	"github.com/glynternet/mon/pkg/filter"
 	"github.com/glynternet/mon/pkg/storage"
 	"github.com/stretchr/testify/assert"
 )
 
-func stubFilter(result bool) AccountFilter {
+func stubFilter(result bool) filter.AccountFilter {
 	return func(_ storage.Account) bool {
 		return result
 	}
@@ -16,7 +17,7 @@ func stubFilter(result bool) AccountFilter {
 func TestAccountFilters_Or(t *testing.T) {
 	for _, test := range []struct {
 		name string
-		AccountFilters
+		filter.AccountFilters
 		storage.Account
 		expected bool
 	}{
@@ -26,27 +27,27 @@ func TestAccountFilters_Or(t *testing.T) {
 		{
 			name:     "single filter passing",
 			expected: true,
-			AccountFilters: AccountFilters{
+			AccountFilters: filter.AccountFilters{
 				stubFilter(true),
 			},
 		},
 		{
 			name: "single filter failing",
-			AccountFilters: AccountFilters{
+			AccountFilters: filter.AccountFilters{
 				stubFilter(false),
 			},
 		},
 		{
 			name:     "multiple filters passing",
 			expected: true,
-			AccountFilters: AccountFilters{
+			AccountFilters: filter.AccountFilters{
 				stubFilter(true),
 				stubFilter(true),
 			},
 		},
 		{
 			name: "multiple filters failing",
-			AccountFilters: AccountFilters{
+			AccountFilters: filter.AccountFilters{
 				stubFilter(false),
 				stubFilter(false),
 			},
@@ -54,7 +55,7 @@ func TestAccountFilters_Or(t *testing.T) {
 		{
 			name:     "multiple filters mixed",
 			expected: true,
-			AccountFilters: AccountFilters{
+			AccountFilters: filter.AccountFilters{
 				stubFilter(false),
 				stubFilter(false),
 				stubFilter(true),

--- a/pkg/filter/account_test.go
+++ b/pkg/filter/account_test.go
@@ -2,7 +2,10 @@ package filter_test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/glynternet/go-accounting/accountingtest"
+	"github.com/glynternet/go-money/currency"
 	"github.com/glynternet/mon/pkg/filter"
 	"github.com/glynternet/mon/pkg/storage"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +42,46 @@ func TestID(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := filter.ID(test.id)
+			match := f(test.Account)
+			assert.Equal(t, test.match, match)
+		})
+	}
+}
+
+func TestCurrency(t *testing.T) {
+
+	for _, test := range []struct {
+		name string
+		storage.Account
+		code  currency.Code
+		match bool
+	}{
+		{
+			name:  "zero-values",
+			match: true,
+		},
+		{
+			name:    "nil code with valid account",
+			Account: storage.Account{Account: *accountingtest.NewAccount(t, "test", accountingtest.NewCurrencyCode(t, "AUP"), time.Time{})},
+		},
+		{
+			name: "nil account with valid code",
+			code: accountingtest.NewCurrencyCode(t, "AUP"),
+		},
+		{
+			name:    "valid code and account with non-matching code",
+			code:    accountingtest.NewCurrencyCode(t, "BUP"),
+			Account: storage.Account{Account: *accountingtest.NewAccount(t, "test", accountingtest.NewCurrencyCode(t, "AUP"), time.Time{})},
+		},
+		{
+			name:    "valid code and account with matching code",
+			code:    accountingtest.NewCurrencyCode(t, "BUP"),
+			Account: storage.Account{Account: *accountingtest.NewAccount(t, "test", accountingtest.NewCurrencyCode(t, "BUP"), time.Time{})},
+			match:   true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := filter.Currency(test.code)
 			match := f(test.Account)
 			assert.Equal(t, test.match, match)
 		})

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -20,5 +20,3 @@ type Storage interface {
 	//UpdateBalance(a Account, b *Balance, us balance.Balance) error
 	//DeleteBalance(a Account, b *Balance) error
 }
-
-//type AccountQuery func (Storage, ...AccountFilter) (*Account, error)


### PR DESCRIPTION
These changes refactor the way that filtering of Accounts is done.

- The preparation of the conditions within the command is now extracted into its own function, making it easier to maintain and reason about the related logic.
- Types that define conditions have been craeted and method created on them (such as `AccountConditions.And` and `AccountConditions.Or`) so that trees of conditions can easily be created for querying/filtering accounts.
- The previously created code has been made more consistent regarding method receivers and function names.
- Tests have been implemented in a filter_test package to ensure that the API is used in the same way as an end user, checking the user's experience.