### PR TITLE
Relativedate

### DIFF
--- a/pkg/date/flag.go
+++ b/pkg/date/flag.go
@@ -46,29 +46,21 @@ func (f *flag) Set(value string) error {
 	}
 	val = strings.ToLower(value)
 
-	y, err := parseYesterday(val)
-	if err == nil {
-		*f = flag{Time: &y}
-		return nil
-	}
-
-	y, err = parseRelative(val)
-	if err == nil {
-		*f = flag{Time: &y}
-		return nil
-	}
-
-	y, err = parseExplicitDate(val)
-	if err == nil {
-		*f = flag{Time: &y}
-		return nil
+	for _, parse := range []func(string) (time.Time, error){
+		parseYesterday,
+		parseRelative,
+		parseExplicitDate,
+	} {
+		d, err := parse(val)
+		if err == nil {
+			*f = flag{Time: &d}
+			return nil
+		}
 	}
 
 	// TODO: use multi error here? We don't want to only provide last error
 	return fmt.Errorf("unsupported date value: %+v", value)
 }
-
-type dateParser func(date string) (time.Time, error)
 
 func parseYesterday(val string) (time.Time, error) {
 	for _, valid := range []string{"yesterday", "y"} {

--- a/pkg/date/flag.go
+++ b/pkg/date/flag.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const dateFormat = "2006-01-02"
+const dateFormat = "2006-1-2"
 
 type flag struct {
 	*time.Time

--- a/pkg/date/flag.go
+++ b/pkg/date/flag.go
@@ -49,7 +49,7 @@ func (f *flag) Set(value string) error {
 	for _, parse := range []func(string) (time.Time, error){
 		parseYesterday,
 		parseRelative,
-		parseExplicitDate,
+		format(dateFormat).parse,
 	} {
 		d, err := parse(val)
 		if err == nil {
@@ -77,7 +77,9 @@ func parseRelative(val string) (time.Time, error) {
 	return d, errors.Wrap(err, "converting ascii to integer")
 }
 
-func parseExplicitDate(val string) (time.Time, error) {
-	d, err := time.Parse(dateFormat, val)
-	return d, errors.Wrapf(err, "parsing into format:%s", dateFormat)
+type format string
+
+func (fmt format) parse(val string) (time.Time, error) {
+	d, err := time.Parse(string(fmt), val)
+	return d, errors.Wrapf(err, "parsing into format:%s", fmt)
 }

--- a/pkg/date/flag.go
+++ b/pkg/date/flag.go
@@ -1,6 +1,7 @@
 package date
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -44,6 +45,12 @@ func (f *flag) Set(value string) error {
 	switch val {
 	case "yesterday", "y":
 		y := time.Now().Add(-time.Hour * 24)
+		*f = flag{Time: &y}
+		return nil
+	}
+	i, err := strconv.Atoi(val)
+	if err == nil {
+		y := time.Now().Add(time.Hour * (24 * time.Duration(i)))
 		*f = flag{Time: &y}
 		return nil
 	}

--- a/pkg/date/flag_test.go
+++ b/pkg/date/flag_test.go
@@ -1,7 +1,7 @@
 package date
 
 import (
-	"strconv"
+	"fmt"
 	"testing"
 	"time"
 
@@ -59,7 +59,7 @@ func TestFlag_Set(t *testing.T) {
 			for key, val := range test.vals {
 				k := key
 				v := val
-				t.Run(strconv.Itoa(k), func(t *testing.T) {
+				t.Run(fmt.Sprintf("%d-%s", k, val), func(t *testing.T) {
 					f := &flag{}
 					err := f.Set(v)
 					if test.err {

--- a/pkg/date/flag_test.go
+++ b/pkg/date/flag_test.go
@@ -51,7 +51,7 @@ func TestFlag_Set(t *testing.T) {
 		},
 		{
 			name: "valid",
-			vals: []string{"2018-03-02"},
+			vals: []string{"2018-03-02", "2018-3-2"},
 			Time: time.Date(2018, 03, 02, 0, 0, 0, 0, time.UTC),
 		},
 	} {

--- a/pkg/date/flag_test.go
+++ b/pkg/date/flag_test.go
@@ -30,6 +30,16 @@ func TestFlag_Set(t *testing.T) {
 			Time: time.Now().Add(time.Hour * -24),
 		},
 		{
+			name: "relative date negative",
+			vals: []string{"-2"},
+			Time: time.Now().Add(time.Hour * (24 * -2)),
+		},
+		{
+			name: "relative date positive",
+			vals: []string{"378", "+378"},
+			Time: time.Now().Add(time.Hour * (24 * 378)),
+		},
+		{
 			name: "nonsense",
 			vals: []string{"bloopy bleep", "!!!!!"},
 			err:  true,

--- a/pkg/date/flag_test.go
+++ b/pkg/date/flag_test.go
@@ -8,49 +8,51 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFlag_Set(t *testing.T) {
+func TestFlag_SetErrors(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		vals []string
-		err  bool
 		time.Time
 	}{
 		{
 			name: "zero-values",
-			err:  true,
 		},
 		{
 			name: "whitespace",
 			vals: []string{"\t\t\t\r"},
-			err:  true,
-		},
-		{
-			name: "yesterday",
-			vals: []string{"yesterday", "YESTERDAY", "y", "Y"},
-			Time: time.Now().Add(time.Hour * -24),
-		},
-		{
-			name: "relative date negative",
-			vals: []string{"-2"},
-			Time: time.Now().Add(time.Hour * (24 * -2)),
-		},
-		{
-			name: "relative date positive",
-			vals: []string{"378", "+378"},
-			Time: time.Now().Add(time.Hour * (24 * 378)),
 		},
 		{
 			name: "nonsense",
 			vals: []string{"bloopy bleep", "!!!!!"},
-			err:  true,
 		},
 		{
 			name: "invalid date format",
-			vals: []string{"02/03", "02-03", "-1000-01-87"},
-			err:  true,
+			vals: []string{"02/03", "-1000-01-87", "03-02"},
 		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for key, val := range test.vals {
+				k := key
+				v := val
+				t.Run(fmt.Sprintf("%d-%s", k, val), func(t *testing.T) {
+					f := &flag{}
+					err := f.Set(v)
+					assert.Nil(t, f.Time)
+					assert.Error(t, err)
+				})
+			}
+		})
+	}
+}
+
+func TestFlag_SetExplicit(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		vals []string
+		time.Time
+	}{
 		{
-			name: "valid",
+			name: "valid explicit",
 			vals: []string{"2018-03-02", "2018-3-2"},
 			Time: time.Date(2018, 03, 02, 0, 0, 0, 0, time.UTC),
 		},
@@ -62,13 +64,48 @@ func TestFlag_Set(t *testing.T) {
 				t.Run(fmt.Sprintf("%d-%s", k, val), func(t *testing.T) {
 					f := &flag{}
 					err := f.Set(v)
-					if test.err {
-						assert.Nil(t, f.Time)
-						assert.Error(t, err)
-						return
-					}
+					assert.NoError(t, err)
 					assert.NotNil(t, f)
-					diff := absDuration(f.Time.Sub(test.Time))
+					assert.Equal(t, test.Time, *f.Time)
+				})
+			}
+		})
+	}
+}
+
+func TestFlag_SetRelative(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		vals         []string
+		relativeDays int
+	}{
+		{
+			name:         "yesterday",
+			vals:         []string{"yesterday", "YESTERDAY", "y", "Y"},
+			relativeDays: -1,
+		},
+		{
+			name:         "relative date negative",
+			vals:         []string{"-2"},
+			relativeDays: -2,
+		},
+		{
+			name:         "relative date positive",
+			vals:         []string{"378", "+378"},
+			relativeDays: 378,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for key, val := range test.vals {
+				k := key
+				v := val
+				t.Run(fmt.Sprintf("%d-%s", k, val), func(t *testing.T) {
+					f := &flag{}
+					expected := time.Now().Add(time.Hour * 24 * time.Duration(test.relativeDays))
+					err := f.Set(v)
+					assert.NoError(t, err)
+					assert.NotNil(t, f)
+					diff := absDuration(f.Time.Sub(expected))
 					acceptableThreshold := time.Millisecond * 10
 					assert.Truef(t,
 						diff < acceptableThreshold,
@@ -76,7 +113,6 @@ func TestFlag_Set(t *testing.T) {
 							"If the difference is still quite small, "+
 							"this could be because of a slow running test.",
 						diff)
-					assert.NoError(t, err)
 				})
 			}
 		})


### PR DESCRIPTION
- Refactor tests, splitting `date.Set` tests into logical groups
Prior to these changes, the tests for setting the flag value were all
within a single large test table.  
This commit splits up the different types of tests – for errors,
explicit and relative dates – into into their own test functions.  
This means that the body of the test functions has become a lot simpler.
- This commit adds support for declaring a number of days relative to the
current time when using the --date flag. Any value that can be parsed into an
integer counts as a valid relative date.
- Extract each parsing logic into separate functions so that they can be 
maintained a bit easier and so that they all have a matching function signature
- Range over a slice of date parsers, allowing parsers in the matching format
 to be easily added.
