### PR TITLE
Not AccountFilter

### DIFF
--- a/cmd/moncli/cmd/accounts.go
+++ b/cmd/moncli/cmd/accounts.go
@@ -25,6 +25,7 @@ import (
 const (
 	keyOpen       = "open"
 	keyIDs        = "ids"
+	keyNotIDs     = "not-ids"
 	keyCurrencies = "currencies"
 	keyQuiet      = "quiet"
 	keyAtDate     = "at-date"
@@ -32,10 +33,10 @@ const (
 )
 
 var (
-	atDate     = date.Flag()
-	sortBy     = sort.NewKey()
-	ids        []uint
-	currencies []string
+	atDate      = date.Flag()
+	sortBy      = sort.NewKey()
+	ids, notIDs []uint
+	currencies  []string
 )
 
 var accountsCmd = &cobra.Command{
@@ -175,6 +176,10 @@ func prepareAccountCondition() (filter.AccountCondition, error) {
 		cs = append(cs, idsCondition(ids))
 	}
 
+	if len(notIDs) > 0 {
+		cs = append(cs, filter.Not(idsCondition(notIDs)))
+	}
+
 	if len(currencies) > 0 {
 		ccs, err := currenciesCondition(currencies)
 		if err != nil {
@@ -223,7 +228,8 @@ func currencyStringsToCodes(css ...string) ([]currency.Code, error) {
 func init() {
 	rootCmd.AddCommand(accountsCmd)
 	accountsCmd.PersistentFlags().Bool(keyOpen, false, "show only open accounts")
-	accountsCmd.PersistentFlags().UintSliceVar(&ids, keyIDs, []uint{}, "filter by ids")
+	accountsCmd.PersistentFlags().UintSliceVar(&ids, keyIDs, []uint{}, "include only these ids")
+	accountsCmd.PersistentFlags().UintSliceVar(&notIDs, keyNotIDs, []uint{}, "include only ids other than these")
 	accountsCmd.PersistentFlags().StringSliceVar(&currencies, keyCurrencies, []string{}, "filter by currencies")
 	accountsCmd.Flags().BoolP(keyQuiet, "q", false, "show only account ids")
 	accountsCmd.PersistentFlags().Var(atDate, keyAtDate, "show balances at a certain date")

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -20,7 +20,15 @@ func (ac AccountCondition) Filter(as storage.Accounts) storage.Accounts {
 			filtered = append(filtered, a)
 		}
 	}
-	return storage.Accounts(filtered)
+	return filtered
+}
+
+// Not produces an AccountCondition that inverts the outcome of the given
+// AccountCondition
+func Not(c AccountCondition) AccountCondition {
+	return func(a storage.Account) bool {
+		return !c(a)
+	}
 }
 
 // Existed produces an AccountCondition that can be used to identify if an

--- a/pkg/filter/account_test.go
+++ b/pkg/filter/account_test.go
@@ -164,6 +164,32 @@ func TestOpenAt(t *testing.T) {
 	}
 }
 
+func TestNot(t *testing.T) {
+	var dummy storage.Account
+	for _, test := range []struct {
+		name string
+		in   bool
+	}{
+		{
+			name: "zero-values",
+		},
+		{
+			name: "inner filter match",
+			in:   true,
+		},
+		{
+			name: "inner filter non-match",
+			in:   false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := filter.Not(stubAccountCondition(test.in))
+			match := f(dummy)
+			assert.Equal(t, !test.in, match)
+		})
+	}
+}
+
 func TestAccountConditions_Or(t *testing.T) {
 	for _, test := range []struct {
 		name string
@@ -282,6 +308,7 @@ func TestAccountConditions_And(t *testing.T) {
 		})
 	}
 }
+
 func TestAccountCondition_Filter(t *testing.T) {
 	matchingID := uint(1)
 	nonmatchingID := uint(2)


### PR DESCRIPTION
These changes:
- Add a Not AccountFilter  
A simple decorator that can be used to invert the result of an 
AccountFilter.
- Add cli flag for not IDs  
Prior to these changes, when querying the store for accounts, there was
no way to supply an exclude list of IDs.  
A flag has been added onto the `moncli accounts` command that can be 
used to provide a list of IDs which are to be excluded from the results
when querying accounts and balances.