### PR TITLE
Add context to error when unable to find balance

### DIFF
--- a/cmd/moncli/cmd/account.go
+++ b/cmd/moncli/cmd/account.go
@@ -461,7 +461,7 @@ func accountBalanceAtTime(store storage.Storage, a storage.Account, at time.Time
 		return balance.Balance{}, errors.Wrapf(err, "no balances for account:%+v", a)
 	}
 	b, err := bbs.AtTime(at)
-	return b, errors.Wrapf(err, "getting balance at time from returned balances", at, a)
+	return b, errors.Wrapf(err, "getting balance at time:%+v from returned balances:%+v", at, bbs)
 }
 
 func init() {


### PR DESCRIPTION
Prior to this commit, there was a sloppily copied error.Wrapf from
another return statement which had some values appened to the message.

These values were removed, as they didn't make sense, and the correct
ones were added.