### PR TITLE
Increase number of retries and backoff period

### DIFF
--- a/pkg/storage/postgres/test/functional/functional_test.go
+++ b/pkg/storage/postgres/test/functional/functional_test.go
@@ -32,7 +32,8 @@ func init() {
 }
 
 func setup() {
-	const retries = 5
+	const retries = 10
+	const backoff = 2 * time.Second
 	errs := make([]error, retries)
 	var i int
 	for i = 0; i < retries; i++ {
@@ -46,7 +47,7 @@ func setup() {
 			break
 		}
 		errs[i] = err
-		time.Sleep(time.Second)
+		time.Sleep(backoff)
 	}
 	if errs[retries-1] != nil {
 		for i, err := range errs {

--- a/test/functional/functional_test.go
+++ b/test/functional/functional_test.go
@@ -31,7 +31,8 @@ func init() {
 }
 
 func setup() {
-	const retries = 5
+	const retries = 10
+	const backoff = 2 * time.Second
 	errs := make([]error, retries)
 	var i int
 	for i = 0; i < retries; i++ {
@@ -45,7 +46,7 @@ func setup() {
 			break
 		}
 		errs[i] = err
-		time.Sleep(time.Second)
+		time.Sleep(backoff)
 	}
 	if errs[retries-1] != nil {
 		for i, err := range errs {


### PR DESCRIPTION
Priot to this change, the connection between the test suite and the
monserve container would often not get established when starting the
tests.

This change doubles both the number of retries to do and the period
in between each retry to give less-powerful machine a better chance to
have the functional tests establish their connection.