### PR TITLE
Use package instead of main.go in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,16 @@
 builds:
 - binary: moncli
-  main: ./cmd/moncli/main.go
+  ldflags:
+     - -w -X github.com/glynternet/mon/cmd/moncli/cmd.version={{.Version}}
+  main: ./cmd/moncli
   env:
   - CGO_ENABLED=0
   goarch:
     - amd64
 - binary: monserve
-  main: ./cmd/monserve/main.go
+  ldflags:
+     - -w -X main.version={{.Version}}
+  main: ./cmd/monserve
   env:
   - CGO_ENABLED=0
   goarch:


### PR DESCRIPTION
By providing explicitly the main.go file to the goreleaser, only the
files that are referenced by main.go become compiled. This meant that
the version.go file within the monserve pkg was not being compiled, so
there was no version subcommand being added to the root command.

This change provides the package using cmd/monserve to the goreleaser
for both monserve and moncli, to avoid this error in future.