### PR TITLE
Remove install and clean rules from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,7 @@ GOBUILD_CMD ?= $(GOBUILD_ENVVARS) go build $(GOBUILD_FLAGS)
 OS ?= linux
 ARCH ?= amd64
 
-all: build install clean
-
 build: moncli monserve
-
-install:
-	cp -v $(BUILD_DIR)/* $(GOPATH)/bin/
-
-clean:
-	rm $(BUILD_DIR)/*
 
 monserve:
 	$(MAKE) cmd-all \


### PR DESCRIPTION
Prior to this change, when running `make` without any arguments, the
binaries would be installed on the local machine and then the build dir
would be deleted. With the move to CI/CD, there is no need to run the
install rule and the clean rule just deletes the compiled binaries,
which may be required for other parts of the CI process.