### PR TITLE
Split up storage and business logic

### DIFF
--- a/cmd/moncli/cmd/account.go
+++ b/cmd/moncli/cmd/account.go
@@ -11,6 +11,7 @@ import (
 	"github.com/glynternet/go-accounting/balance"
 	"github.com/glynternet/go-money/currency"
 	"github.com/glynternet/mon/internal/accountbalance"
+	"github.com/glynternet/mon/internal/model"
 	"github.com/glynternet/mon/pkg/date"
 	"github.com/glynternet/mon/pkg/storage"
 	"github.com/glynternet/mon/pkg/table"
@@ -369,7 +370,7 @@ var accountBalancesCmd = &cobra.Command{
 
 		table.Accounts(storage.Accounts{*a}, os.Stdout)
 
-		bs, err := c.SelectAccountBalances(*a)
+		bs, err := c.SelectAccountBalances((*a).ID)
 		if err != nil {
 			return errors.Wrap(err, "selecting account balances")
 		}
@@ -452,7 +453,7 @@ var accountBalanceCmd = &cobra.Command{
 }
 
 func accountBalanceAtTime(store storage.Storage, a storage.Account, at time.Time) (balance.Balance, error) {
-	bs, err := store.SelectAccountBalances(a)
+	bs, err := model.SelectAccountBalances(store, a)
 	if err != nil {
 		return balance.Balance{}, errors.Wrapf(err, "selecting balances for account: %+v", a)
 	}

--- a/cmd/moncli/cmd/account.go
+++ b/cmd/moncli/cmd/account.go
@@ -162,7 +162,7 @@ var accountReopenCmd = &cobra.Command{
 			return errors.Wrap(err, "creating updates account from selected account")
 		}
 
-		b, err := c.UpdateAccount(*a, *us)
+		b, err := c.UpdateAccount(a.ID, *us)
 		if err != nil {
 			return errors.Wrap(err, "applying updates")
 		}
@@ -241,7 +241,7 @@ var accountCloseCmd = &cobra.Command{
 			return errors.Wrap(err, "creating updates account")
 		}
 
-		u, err := c.UpdateAccount(*a, *us)
+		u, err := c.UpdateAccount(a.ID, *us)
 		if err != nil {
 			return errors.Wrap(err, "updating account")
 		}
@@ -293,7 +293,7 @@ the same as the original account`,
 			return errors.Wrap(err, "creating account for update")
 		}
 
-		u, err := c.UpdateAccount(*a, *us)
+		u, err := c.UpdateAccount(a.ID, *us)
 		if err != nil {
 			return errors.Wrap(err, "updating account")
 		}
@@ -338,7 +338,7 @@ var accountRenameCmd = &cobra.Command{
 			return errors.Wrap(err, "creating new account for update")
 		}
 
-		u, err := c.UpdateAccount(*a, *us)
+		u, err := c.UpdateAccount(a.ID, *us)
 		if err != nil {
 			return errors.Wrap(err, "updating account")
 		}

--- a/cmd/moncli/cmd/account.go
+++ b/cmd/moncli/cmd/account.go
@@ -11,7 +11,6 @@ import (
 	"github.com/glynternet/go-accounting/balance"
 	"github.com/glynternet/go-money/currency"
 	"github.com/glynternet/mon/internal/accountbalance"
-	"github.com/glynternet/mon/internal/model"
 	"github.com/glynternet/mon/pkg/date"
 	"github.com/glynternet/mon/pkg/storage"
 	"github.com/glynternet/mon/pkg/table"
@@ -123,7 +122,7 @@ var accountOpenCmd = &cobra.Command{
 			return errors.Wrap(err, "inserting new account")
 		}
 
-		b, err := c.InsertBalance(*i, balance.Balance{
+		b, err := c.InsertBalance((*i).ID, balance.Balance{
 			Date:   i.Account.Opened(),
 			Amount: viper.GetInt(keyOpeningBalance),
 		})
@@ -224,7 +223,7 @@ var accountCloseCmd = &cobra.Command{
 			return errors.Wrap(err, "selecting account")
 		}
 
-		b, err := c.InsertBalance(*a, balance.Balance{
+		b, err := c.InsertBalance((*a).ID, balance.Balance{
 			Date:   closed,
 			Amount: viper.GetInt(keyClosingBalance),
 		})
@@ -409,7 +408,7 @@ var accountBalanceInsertCmd = &cobra.Command{
 			t = *balanceDate.Time
 		}
 
-		b, err := c.InsertBalance(*a, balance.Balance{
+		b, err := c.InsertBalance((*a).ID, balance.Balance{
 			Date:   t,
 			Amount: viper.GetInt(keyAmount),
 		})
@@ -453,7 +452,7 @@ var accountBalanceCmd = &cobra.Command{
 }
 
 func accountBalanceAtTime(store storage.Storage, a storage.Account, at time.Time) (balance.Balance, error) {
-	bs, err := model.SelectAccountBalances(store, a)
+	bs, err := store.SelectAccountBalances(a.ID)
 	if err != nil {
 		return balance.Balance{}, errors.Wrapf(err, "selecting balances for account: %+v", a)
 	}

--- a/cmd/moncli/cmd/account.go
+++ b/cmd/moncli/cmd/account.go
@@ -162,7 +162,7 @@ var accountReopenCmd = &cobra.Command{
 			return errors.Wrap(err, "creating updates account from selected account")
 		}
 
-		b, err := c.UpdateAccount(a, us)
+		b, err := c.UpdateAccount(*a, *us)
 		if err != nil {
 			return errors.Wrap(err, "applying updates")
 		}
@@ -241,7 +241,7 @@ var accountCloseCmd = &cobra.Command{
 			return errors.Wrap(err, "creating updates account")
 		}
 
-		u, err := c.UpdateAccount(a, us)
+		u, err := c.UpdateAccount(*a, *us)
 		if err != nil {
 			return errors.Wrap(err, "updating account")
 		}
@@ -293,7 +293,7 @@ the same as the original account`,
 			return errors.Wrap(err, "creating account for update")
 		}
 
-		u, err := c.UpdateAccount(a, us)
+		u, err := c.UpdateAccount(*a, *us)
 		if err != nil {
 			return errors.Wrap(err, "updating account")
 		}
@@ -338,7 +338,7 @@ var accountRenameCmd = &cobra.Command{
 			return errors.Wrap(err, "creating new account for update")
 		}
 
-		u, err := c.UpdateAccount(a, us)
+		u, err := c.UpdateAccount(*a, *us)
 		if err != nil {
 			return errors.Wrap(err, "updating account")
 		}

--- a/internal/client/account.go
+++ b/internal/client/account.go
@@ -52,8 +52,8 @@ func (c Client) InsertAccount(a account.Account) (*storage.Account, error) {
 }
 
 // UpdateAccount will updated a currently stored account with updates provided by another account
-func (c Client) UpdateAccount(account storage.Account, updates account.Account) (*storage.Account, error) {
-	endpoint := fmt.Sprintf(router.EndpointFmtAccountUpdate, account.ID)
+func (c Client) UpdateAccount(id uint, updates account.Account) (*storage.Account, error) {
+	endpoint := fmt.Sprintf(router.EndpointFmtAccountUpdate, id)
 	bs, err := c.postAccountToEndpoint(endpoint, updates)
 	if err != nil {
 		return nil, errors.Wrapf(err, "posting account to endpoint %s", endpoint)

--- a/internal/client/account.go
+++ b/internal/client/account.go
@@ -52,9 +52,9 @@ func (c Client) InsertAccount(a account.Account) (*storage.Account, error) {
 }
 
 // UpdateAccount will updated a currently stored account with updates provided by another account
-func (c Client) UpdateAccount(account *storage.Account, updates *account.Account) (*storage.Account, error) {
+func (c Client) UpdateAccount(account storage.Account, updates account.Account) (*storage.Account, error) {
 	endpoint := fmt.Sprintf(router.EndpointFmtAccountUpdate, account.ID)
-	bs, err := c.postAccountToEndpoint(endpoint, *updates)
+	bs, err := c.postAccountToEndpoint(endpoint, updates)
 	if err != nil {
 		return nil, errors.Wrapf(err, "posting account to endpoint %s", endpoint)
 	}

--- a/internal/client/balance.go
+++ b/internal/client/balance.go
@@ -13,8 +13,8 @@ import (
 )
 
 // SelectAccountBalances will select the Balances that are stored for a given Account
-func (c Client) SelectAccountBalances(a storage.Account) (*storage.Balances, error) {
-	return c.getBalancesFromEndpoint(fmt.Sprintf(router.EndpointFmtAccountBalances, a.ID))
+func (c Client) SelectAccountBalances(id uint) (*storage.Balances, error) {
+	return c.getBalancesFromEndpoint(fmt.Sprintf(router.EndpointFmtAccountBalances, id))
 }
 
 func (c Client) getBalancesFromEndpoint(e string) (*storage.Balances, error) {

--- a/internal/client/balance.go
+++ b/internal/client/balance.go
@@ -31,8 +31,8 @@ func (c Client) getBalancesFromEndpoint(e string) (*storage.Balances, error) {
 }
 
 // InsertBalance will insert a balance for a given Account
-func (c Client) InsertBalance(a storage.Account, b balance.Balance) (*storage.Balance, error) {
-	endpoint := fmt.Sprintf(router.EndpointFmtAccountBalanceInsert, a.ID)
+func (c Client) InsertBalance(accountID uint, b balance.Balance) (*storage.Balance, error) {
+	endpoint := fmt.Sprintf(router.EndpointFmtAccountBalanceInsert, accountID)
 	bs, err := c.postBalanceToEndpoint(
 		endpoint, b,
 	)

--- a/internal/client/client_integration_test.go
+++ b/internal/client/client_integration_test.go
@@ -120,7 +120,7 @@ func TestClient_SelectAccountBalances(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 
 	go func() {
-		selected, err := client.SelectAccountBalances(*s.Account) // id doesn't matter when mocking
+		selected, err := client.SelectAccountBalances((*s).Account.ID) // id doesn't matter when mocking
 		assert.NoError(t, err)
 		assert.NotNil(t, selected)
 		assert.Equal(t, s.Balances, selected)

--- a/internal/client/client_integration_test.go
+++ b/internal/client/client_integration_test.go
@@ -167,9 +167,14 @@ func TestClient_InsertAccount(t *testing.T) {
 
 func TestClient_InsertBalance(t *testing.T) {
 	expected := &storage.Balance{ID: 293}
+	now := time.Now()
+	account := &storage.Account{
+		Account: *accountingtest.NewAccount(t, "test account", accountingtest.NewCurrencyCode(t, "ABC"), now),
+	}
+	insert := balance.Balance{Date: now}
 
 	s := &storagetest.Storage{
-		Account: &storage.Account{ID: 51},
+		Account: account,
 		Balance: expected,
 	}
 
@@ -183,7 +188,7 @@ func TestClient_InsertBalance(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 
 	go func() {
-		inserted, err := client.InsertBalance(storage.Account{}, balance.Balance{})
+		inserted, err := client.InsertBalance(0, insert)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, inserted)
 		close(errCh)

--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -12,7 +12,7 @@ import (
 // account data. The updates will be verified to ensure that any data to be
 // used will be logically sound with the balances and other account details.
 func UpdateAccount(s storage.Storage, a storage.Account, updates account.Account) (*storage.Account, error) {
-	bs, err := s.SelectAccountBalances(a)
+	bs, err := s.SelectAccountBalances(a.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "selecting Account Balances for update validation")
 	}

--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -27,3 +27,12 @@ func UpdateAccount(s storage.Storage, a storage.Account, updates account.Account
 	dba, err := s.UpdateAccount(a.ID, updates)
 	return dba, errors.Wrap(err, "updating account")
 }
+
+// DeleteAccount deletes an account with the given id
+func DeleteAccount(s storage.Storage, id uint) error {
+	_, err := s.SelectAccount(id)
+	if err != nil {
+		return errors.Wrap(err, "selecting account to delete")
+	}
+	return errors.Wrap(s.DeleteAccount(id), "deleting account")
+}

--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/glynternet/go-accounting/account"
+	"github.com/glynternet/mon/pkg/storage"
+	"github.com/pkg/errors"
+)
+
+// UpdateAccount updates a stored account to reflect the details of some other
+// account data. The updates will be verified to ensure that any data to be
+// used will be logically sound with the balances and other account details.
+func UpdateAccount(s storage.Storage, a storage.Account, updates account.Account) (*storage.Account, error) {
+	bs, err := s.SelectAccountBalances(a)
+	if err != nil {
+		return nil, errors.Wrap(err, "selecting Account Balances for update validation")
+	}
+	if bs != nil {
+		for _, b := range *bs {
+			err := updates.ValidateBalance(b.Balance)
+			if err != nil {
+				return nil, fmt.Errorf("update would make balance invalid: %v", err)
+			}
+		}
+	}
+	dba, err := s.UpdateAccount(a.ID, updates)
+	return dba, errors.Wrap(err, "updating account")
+}

--- a/internal/model/account_test.go
+++ b/internal/model/account_test.go
@@ -1,0 +1,73 @@
+package model_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/glynternet/go-accounting/account"
+	"github.com/glynternet/go-accounting/accountingtest"
+	"github.com/glynternet/go-accounting/balance"
+	"github.com/glynternet/mon/internal/model"
+	"github.com/glynternet/mon/pkg/storage"
+	"github.com/glynternet/mon/pkg/storage/storagetest"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateAccount(t *testing.T) {
+	t.Run("select account balances error", func(t *testing.T) {
+		expectedErr := errors.New("balances error")
+		s := &storagetest.Storage{
+			BalancesErr: expectedErr,
+		}
+
+		updated, actualErr := model.UpdateAccount(s, storage.Account{}, account.Account{})
+		assert.Nil(t, updated)
+		assert.Error(t, actualErr)
+		assert.Equal(t, expectedErr, errors.Cause(actualErr))
+		assert.Contains(t, actualErr.Error(), "selecting Account Balances for update validation")
+	})
+
+	now := time.Now()
+	s := &storagetest.Storage{
+		Balances: &storage.Balances{
+			storage.Balance{
+				Balance: balance.Balance{Date: now},
+			},
+		},
+		AccountErr: errors.New("account error"),
+	}
+
+	a := accountingtest.NewAccount(t, "A", accountingtest.NewCurrencyCode(t, "YEN"), now)
+	initial := storage.Account{
+		ID:      999,
+		Account: *a,
+	}
+
+	t.Run("invalid with balances", func(t *testing.T) {
+		updates := accountingtest.NewAccount(t,
+			"B",
+			accountingtest.NewCurrencyCode(t, "GBP"),
+			now.Add(time.Hour),
+			account.CloseTime(now.Add(24*time.Hour)),
+		)
+
+		updated, err := model.UpdateAccount(s, initial, *updates)
+		assert.Nil(t, updated)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "update would make balance invalid")
+	})
+
+	t.Run("update against storage", func(t *testing.T) {
+		updates := accountingtest.NewAccount(t,
+			"B",
+			accountingtest.NewCurrencyCode(t, "GBP"),
+			now.Add(-time.Hour),
+			account.CloseTime(now.Add(24*time.Hour)),
+		)
+
+		_, err := model.UpdateAccount(s, initial, *updates)
+		assert.Equal(t, initial.ID, s.LastAccountID)
+		assert.Equal(t, s.AccountErr, errors.Cause(err))
+	})
+}

--- a/internal/model/account_test.go
+++ b/internal/model/account_test.go
@@ -71,3 +71,20 @@ func TestUpdateAccount(t *testing.T) {
 		assert.Equal(t, s.AccountErr, errors.Cause(err))
 	})
 }
+
+func TestDeleteAccount(t *testing.T) {
+	t.Run("SelectAccount error", func(t *testing.T) {
+		s := &storagetest.Storage{
+			AccountErr: errors.New("account error"),
+		}
+		err := model.DeleteAccount(s, 0)
+		assert.Equal(t, s.AccountErr, errors.Cause(err))
+		assert.Contains(t, err.Error(), "selecting account to delete")
+	})
+
+	t.Run("check id is passed", func(t *testing.T) {
+		s := &storagetest.Storage{}
+		_ = model.DeleteAccount(s, 999)
+		assert.Equal(t, uint(999), s.LastAccountID)
+	})
+}

--- a/internal/model/balance.go
+++ b/internal/model/balance.go
@@ -1,0 +1,10 @@
+package model
+
+import "github.com/glynternet/mon/pkg/storage"
+
+// SelectAccountBalances returns all Balances for a given Account and any
+// errors that occur whilst attempting to retrieve the Balances. The Balances
+// are sorted by chronological order then by the id of the Balance in the DB
+func SelectAccountBalances(s storage.Storage, a storage.Account) (*storage.Balances, error) {
+	return s.SelectAccountBalances(a.ID)
+}

--- a/internal/model/balance.go
+++ b/internal/model/balance.go
@@ -1,10 +1,26 @@
 package model
 
-import "github.com/glynternet/mon/pkg/storage"
+import (
+	"github.com/glynternet/go-accounting/balance"
+	"github.com/glynternet/mon/pkg/storage"
+	"github.com/pkg/errors"
+)
 
 // SelectAccountBalances returns all Balances for a given Account and any
 // errors that occur whilst attempting to retrieve the Balances. The Balances
 // are sorted by chronological order then by the id of the Balance in the DB
 func SelectAccountBalances(s storage.Storage, a storage.Account) (*storage.Balances, error) {
 	return s.SelectAccountBalances(a.ID)
+}
+
+// InsertBalance will insert a Balance into the given storage using the value
+// of the given storage.Account. InsertBalance will perform any logic checks
+// before attempting to insert the balance into the given Storage.
+func InsertBalance(s storage.Storage, a storage.Account, b balance.Balance) (*storage.Balance, error) {
+	err := a.Account.ValidateBalance(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "validating balance")
+	}
+	dbb, err := s.InsertBalance(a.ID, b)
+	return dbb, errors.Wrap(err, "inserting balance")
 }

--- a/internal/model/balance_test.go
+++ b/internal/model/balance_test.go
@@ -1,0 +1,43 @@
+package model_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/glynternet/go-accounting/accountingtest"
+	"github.com/glynternet/go-accounting/balance"
+	"github.com/glynternet/mon/internal/model"
+	"github.com/glynternet/mon/pkg/storage"
+	"github.com/glynternet/mon/pkg/storage/storagetest"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInsertBalance(t *testing.T) {
+	t.Run("validation error", func(t *testing.T) {
+		b, err := model.InsertBalance(nil, storage.Account{}, balance.Balance{})
+		assert.Nil(t, b)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "validating balance")
+	})
+
+	t.Run("id is passed", func(t *testing.T) {
+		s := &storagetest.Storage{
+			Balance:    &storage.Balance{},
+			BalanceErr: errors.New("insert balance error"),
+		}
+		now := time.Now()
+		b, err := model.InsertBalance(s,
+			storage.Account{
+				ID: 9183,
+				Account: *accountingtest.NewAccount(t,
+					"test account",
+					accountingtest.NewCurrencyCode(t, "ABC"),
+					now),
+			},
+			balance.Balance{Date: now})
+		assert.Equal(t, s.BalanceErr, errors.Cause(err))
+		assert.Equal(t, s.Balance, b)
+		assert.Equal(t, uint(9183), s.LastAccountID)
+	})
+}

--- a/internal/router/accounthandlers.go
+++ b/internal/router/accounthandlers.go
@@ -101,7 +101,7 @@ func (env *environment) muxAccountUpdateHandlerFunc(r *http.Request) (int, inter
 }
 
 func (env *environment) handlerUpdateAccount(a storage.Account, updates account.Account) (int, interface{}, error) {
-	updated, err := env.storage.UpdateAccount(&a, &updates)
+	updated, err := env.storage.UpdateAccount(a, updates)
 	if err != nil {
 		return http.StatusBadRequest, nil, err
 	}

--- a/internal/router/accounthandlers.go
+++ b/internal/router/accounthandlers.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/glynternet/go-accounting/account"
+	"github.com/glynternet/mon/internal/model"
 	"github.com/glynternet/mon/pkg/storage"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -101,7 +102,7 @@ func (env *environment) muxAccountUpdateHandlerFunc(r *http.Request) (int, inter
 }
 
 func (env *environment) handlerUpdateAccount(a storage.Account, updates account.Account) (int, interface{}, error) {
-	updated, err := env.storage.UpdateAccount(a, updates)
+	updated, err := model.UpdateAccount(env.storage, a, updates)
 	if err != nil {
 		return http.StatusBadRequest, nil, err
 	}

--- a/internal/router/accounthandlers.go
+++ b/internal/router/accounthandlers.go
@@ -118,7 +118,7 @@ func (env *environment) muxAccountDeleteHandlerFunc(r *http.Request) (int, inter
 }
 
 func (env *environment) handlerDeleteAccount(id uint) (int, interface{}, error) {
-	err := env.storage.DeleteAccount(id)
+	err := model.DeleteAccount(env.storage, id)
 	if err != nil {
 		return http.StatusBadRequest, nil, errors.Wrapf(err, "deleting Account with id:%d from storage", id)
 	}

--- a/internal/router/balancehandlers.go
+++ b/internal/router/balancehandlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/glynternet/go-accounting/balance"
+	"github.com/glynternet/mon/internal/model"
 	"github.com/glynternet/mon/pkg/storage"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -18,7 +19,7 @@ func (env *environment) balances(accountID uint) (int, interface{}, error) {
 		return http.StatusBadRequest, nil, errors.Wrapf(err, "selecting account with id %d", accountID)
 	}
 	var bs *storage.Balances
-	bs, err = env.storage.SelectAccountBalances(*a)
+	bs, err = model.SelectAccountBalances(env.storage, *a)
 	if err != nil {
 		return http.StatusBadRequest, nil, errors.Wrapf(err, "selecting balances for account %+v", *a)
 	}

--- a/internal/router/balancehandlers.go
+++ b/internal/router/balancehandlers.go
@@ -39,7 +39,7 @@ func (env *environment) insertBalance(accountID uint, b balance.Balance) (int, i
 	if err != nil {
 		return http.StatusBadRequest, nil, errors.Wrap(err, "selecting account")
 	}
-	inserted, err := env.storage.InsertBalance(*a, b)
+	inserted, err := model.InsertBalance(env.storage, *a, b)
 	if err != nil {
 		return http.StatusBadRequest, nil, errors.Wrap(err, "inserting balance")
 	}

--- a/pkg/storage/postgres/account.go
+++ b/pkg/storage/postgres/account.go
@@ -96,26 +96,8 @@ func (pg postgres) InsertAccount(a account.Account) (*storage.Account, error) {
 	return dba, errors.Wrap(err, "querying Account")
 }
 
-// UpdateAccount updates a stored account to reflect the details of some other
-// account data. The updates will be verified to ensure that any data to be
-// used will be logically sound with the balances and other account details.
-func (pg postgres) UpdateAccount(a storage.Account, updates account.Account) (*storage.Account, error) {
-	bs, err := pg.SelectAccountBalances(a)
-	if err != nil {
-		return nil, errors.Wrap(err, "selecting Account Balances for update validation")
-	}
-	for _, b := range *bs {
-		err := updates.ValidateBalance(b.Balance)
-		if err != nil {
-			return nil, fmt.Errorf("update would make balance invalid: %v", err)
-		}
-	}
-	dba, err := pg.updateAccount(a.ID, updates)
-	return dba, errors.Wrap(err, "updating account")
-}
-
-// updateAccount updates the account at a given id with the values from the given account.Account
-func (pg postgres) updateAccount(id uint, updates account.Account) (*storage.Account, error) {
+// UpdateAccount updates the account at a given id with the values from the given account.Account
+func (pg postgres) UpdateAccount(id uint, updates account.Account) (*storage.Account, error) {
 	return queryAccount(
 		pg.db,
 		queryUpdateAccount,

--- a/pkg/storage/postgres/account.go
+++ b/pkg/storage/postgres/account.go
@@ -111,15 +111,6 @@ func (pg postgres) UpdateAccount(id uint, updates account.Account) (*storage.Acc
 
 // DeleteAccount deletes an account with the given id
 func (pg postgres) DeleteAccount(id uint) error {
-	_, err := pg.SelectAccount(id)
-	if err != nil {
-		return errors.Wrap(err, "selecting account to delete")
-	}
-	return errors.Wrap(pg.deleteAccount(id), "deleting account")
-}
-
-// deleteAccount deletes an account with the given id
-func (pg postgres) deleteAccount(id uint) error {
 	r, err := pg.db.Exec(queryDeleteAccount, time.Now(), id)
 	if err != nil {
 		return errors.Wrap(err, "executing query")

--- a/pkg/storage/postgres/account.go
+++ b/pkg/storage/postgres/account.go
@@ -127,11 +127,17 @@ func (pg postgres) updateAccount(id uint, updates account.Account) (*storage.Acc
 	)
 }
 
+// DeleteAccount deletes an account with the given id
 func (pg postgres) DeleteAccount(id uint) error {
 	_, err := pg.SelectAccount(id)
 	if err != nil {
 		return errors.Wrap(err, "selecting account to delete")
 	}
+	return errors.Wrap(pg.deleteAccount(id), "deleting account")
+}
+
+// deleteAccount deletes an account with the given id
+func (pg postgres) deleteAccount(id uint) error {
 	r, err := pg.db.Exec(queryDeleteAccount, time.Now(), id)
 	if err != nil {
 		return errors.Wrap(err, "executing query")
@@ -146,6 +152,9 @@ func (pg postgres) DeleteAccount(id uint) error {
 	return nil
 }
 
+// do not export this function.
+// The use of interface{} here is deemed to be acceptable here because it is only used within the
+// context of this package
 func queryAccount(db *sql.DB, queryString string, values ...interface{}) (*storage.Account, error) {
 	as, err := queryAccounts(db, queryString, values...)
 	if err != nil {

--- a/pkg/storage/postgres/balance.go
+++ b/pkg/storage/postgres/balance.go
@@ -77,16 +77,7 @@ func (pg postgres) SelectBalanceByAccountAndID(a storage.Account, balanceID uint
 	return nil, fmt.Errorf("no balance with id %d for account", balanceID)
 }
 
-func (pg postgres) InsertBalance(a storage.Account, b balance.Balance) (*storage.Balance, error) {
-	err := a.Account.ValidateBalance(b)
-	if err != nil {
-		return nil, errors.Wrap(err, "validating balance")
-	}
-	dbb, err := pg.insertBalance(a.ID, b)
-	return dbb, errors.Wrap(err, "inserting balance")
-}
-
-func (pg postgres) insertBalance(accountID uint, b balance.Balance) (*storage.Balance, error) {
+func (pg postgres) InsertBalance(accountID uint, b balance.Balance) (*storage.Balance, error) {
 	return queryBalance(pg.db, balancesInsertBalance, accountID, b.Date, b.Amount)
 }
 

--- a/pkg/storage/postgres/balance.go
+++ b/pkg/storage/postgres/balance.go
@@ -54,26 +54,18 @@ var (
 		balancesTable)
 )
 
-// SelectAccountBalances returns all Balances for a given Account and any
+// SelectAccountBalances returns all Balances for a given account ID and any
 // errors that occur whilst attempting to retrieve the Balances. The Balances
 // are sorted by chronological order then by the id of the Balance in the DB
-func (pg postgres) SelectAccountBalances(a storage.Account) (*storage.Balances, error) {
-	return pg.selectBalancesForAccountID(a.ID)
-}
-
-// selectBalancesForAccountID returns all Balance items, as a single Balances
-// item, for a given account ID number in the given database, along with any
-// errors that occur whilst attempting to retrieve the Balances. The Balances
-// are sorted by chronological order then by the id of the Balance in the DB
-func (pg postgres) selectBalancesForAccountID(accountID uint) (*storage.Balances, error) {
-	return queryBalances(pg.db, balancesSelectBalancesForAccountID, accountID)
+func (pg postgres) SelectAccountBalances(id uint) (*storage.Balances, error) {
+	return queryBalances(pg.db, balancesSelectBalancesForAccountID, id)
 }
 
 // SelectBalanceByAccountAndID selects a balance with a given ID within a given
 // account. An error will be returned if no balance can be found with the ID
 // for the given account.
 func (pg postgres) SelectBalanceByAccountAndID(a storage.Account, balanceID uint) (*storage.Balance, error) {
-	bs, err := pg.SelectAccountBalances(a)
+	bs, err := pg.SelectAccountBalances(a.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "selecting account balances for account %+v")
 	}

--- a/pkg/storage/postgres/balance.go
+++ b/pkg/storage/postgres/balance.go
@@ -90,8 +90,12 @@ func (pg postgres) InsertBalance(a storage.Account, b balance.Balance) (*storage
 	if err != nil {
 		return nil, errors.Wrap(err, "validating balance")
 	}
-	dbb, err := queryBalance(pg.db, balancesInsertBalance, a.ID, b.Date, b.Amount)
-	return dbb, errors.Wrap(err, "querying balance")
+	dbb, err := pg.insertBalance(a.ID, b)
+	return dbb, errors.Wrap(err, "inserting balance")
+}
+
+func (pg postgres) insertBalance(accountID uint, b balance.Balance) (*storage.Balance, error) {
+	return queryBalance(pg.db, balancesInsertBalance, accountID, b.Date, b.Amount)
 }
 
 func (pg postgres) DeleteBalance(id uint) error {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,7 +16,7 @@ type Storage interface {
 	DeleteAccount(id uint) error
 	//
 	InsertBalance(a Account, b balance.Balance) (*Balance, error)
-	SelectAccountBalances(Account) (*Balances, error)
+	SelectAccountBalances(id uint) (*Balances, error)
 	//UpdateBalance(a Account, b *Balance, us balance.Balance) error
 	DeleteBalance(id uint) error
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -11,7 +11,7 @@ type Storage interface {
 	Close() error
 	InsertAccount(a account.Account) (*Account, error)
 	SelectAccount(id uint) (*Account, error)
-	UpdateAccount(a Account, updates account.Account) (*Account, error)
+	UpdateAccount(id uint, updates account.Account) (*Account, error)
 	SelectAccounts() (*Accounts, error)
 	DeleteAccount(id uint) error
 	//

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -11,7 +11,7 @@ type Storage interface {
 	Close() error
 	InsertAccount(a account.Account) (*Account, error)
 	SelectAccount(id uint) (*Account, error)
-	UpdateAccount(a *Account, updates *account.Account) (*Account, error)
+	UpdateAccount(a Account, updates account.Account) (*Account, error)
 	SelectAccounts() (*Accounts, error)
 	DeleteAccount(id uint) error
 	//

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -15,7 +15,7 @@ type Storage interface {
 	SelectAccounts() (*Accounts, error)
 	DeleteAccount(id uint) error
 	//
-	InsertBalance(a Account, b balance.Balance) (*Balance, error)
+	InsertBalance(accountID uint, b balance.Balance) (*Balance, error)
 	SelectAccountBalances(id uint) (*Balances, error)
 	//UpdateBalance(a Account, b *Balance, us balance.Balance) error
 	DeleteBalance(id uint) error

--- a/pkg/storage/storagetest/storage.go
+++ b/pkg/storage/storagetest/storage.go
@@ -67,6 +67,7 @@ func (s *Storage) InsertBalance(storage.Account, balance.Balance) (*storage.Bala
 func (s *Storage) DeleteBalance(_ uint) error { return s.Err }
 
 // SelectAccountBalances stubs the storage.SelectAccountBalances method
-func (s *Storage) SelectAccountBalances(storage.Account) (*storage.Balances, error) {
+func (s *Storage) SelectAccountBalances(id uint) (*storage.Balances, error) {
+	s.LastAccountID = id
 	return s.Balances, s.BalancesErr
 }

--- a/pkg/storage/storagetest/storage.go
+++ b/pkg/storage/storagetest/storage.go
@@ -22,6 +22,8 @@ type Storage struct {
 
 	*storage.Balances
 	BalancesErr error
+
+	LastAccountID uint
 }
 
 // Available stubs storage.Available method
@@ -36,18 +38,25 @@ func (s *Storage) InsertAccount(account.Account) (*storage.Account, error) {
 }
 
 // UpdateAccount stubs the storage.UpdateAccount method
-func (s *Storage) UpdateAccount(a storage.Account, updates account.Account) (*storage.Account, error) {
+func (s *Storage) UpdateAccount(id uint, updates account.Account) (*storage.Account, error) {
+	s.LastAccountID = id
 	return s.Account, s.AccountErr
 }
 
 // SelectAccount stubs the storage.SelectAccount method
-func (s *Storage) SelectAccount(uint) (*storage.Account, error) { return s.Account, s.AccountErr }
+func (s *Storage) SelectAccount(id uint) (*storage.Account, error) {
+	s.LastAccountID = id
+	return s.Account, s.AccountErr
+}
 
 // SelectAccounts stubs the storage.SelectAccounts method
 func (s *Storage) SelectAccounts() (*storage.Accounts, error) { return s.Accounts, s.Err }
 
 // DeleteAccount stubs the storage.DeleteAccount method
-func (s *Storage) DeleteAccount(uint) error { return s.AccountErr }
+func (s *Storage) DeleteAccount(id uint) error {
+	s.LastAccountID = id
+	return s.AccountErr
+}
 
 // InsertBalance stubs the storage.InsertBalance method
 func (s *Storage) InsertBalance(storage.Account, balance.Balance) (*storage.Balance, error) {

--- a/pkg/storage/storagetest/storage.go
+++ b/pkg/storage/storagetest/storage.go
@@ -59,7 +59,8 @@ func (s *Storage) DeleteAccount(id uint) error {
 }
 
 // InsertBalance stubs the storage.InsertBalance method
-func (s *Storage) InsertBalance(storage.Account, balance.Balance) (*storage.Balance, error) {
+func (s *Storage) InsertBalance(accountID uint, _ balance.Balance) (*storage.Balance, error) {
+	s.LastAccountID = accountID
 	return s.Balance, s.BalanceErr
 }
 

--- a/pkg/storage/storagetest/storage.go
+++ b/pkg/storage/storagetest/storage.go
@@ -36,7 +36,7 @@ func (s *Storage) InsertAccount(account.Account) (*storage.Account, error) {
 }
 
 // UpdateAccount stubs the storage.UpdateAccount method
-func (s *Storage) UpdateAccount(a *storage.Account, updates *account.Account) (*storage.Account, error) {
+func (s *Storage) UpdateAccount(a storage.Account, updates account.Account) (*storage.Account, error) {
 	return s.Account, s.AccountErr
 }
 

--- a/pkg/storage/storagetest/test.go
+++ b/pkg/storage/storagetest/test.go
@@ -149,7 +149,7 @@ func insertDeleteAndRetrieveBalances(t *testing.T, store storage.Storage) {
 
 	// assert that all accounts contain no balances
 	for _, a := range *as {
-		bs, err := store.SelectAccountBalances(a)
+		bs, err := store.SelectAccountBalances(a.ID)
 		common.FatalIfError(t, err, "selecting account balances")
 		assert.Len(t, *bs, 0)
 
@@ -162,7 +162,7 @@ func insertDeleteAndRetrieveBalances(t *testing.T, store storage.Storage) {
 			t.FailNow()
 		}
 
-		bs, err = store.SelectAccountBalances(a)
+		bs, err = store.SelectAccountBalances(a.ID)
 		common.FatalIfError(t, err, "selecting account balances")
 		assert.Len(t, *bs, 1)
 
@@ -170,7 +170,7 @@ func insertDeleteAndRetrieveBalances(t *testing.T, store storage.Storage) {
 		err = store.DeleteBalance(inserted.ID)
 		assert.NoError(t, err)
 
-		bs, err = store.SelectAccountBalances(a)
+		bs, err = store.SelectAccountBalances(a.ID)
 		common.FatalIfError(t, err, "selecting account balances")
 		assert.Len(t, *bs, 0)
 
@@ -224,7 +224,7 @@ func insertAndDeleteAccounts(t *testing.T, store storage.Storage) {
 	}
 	var abs []AccountBalances
 	for _, a := range *selectedBefore {
-		bs, err := store.SelectAccountBalances(a)
+		bs, err := store.SelectAccountBalances(a.ID)
 		if err != nil {
 			t.Fatal(errors.Wrapf(err, "selecting account balances for account %+v", a))
 		}
@@ -276,7 +276,7 @@ func insertAndDeleteAccounts(t *testing.T, store storage.Storage) {
 		for i := range *selectedAfter {
 			afterAccount := (*selectedAfter)[i]
 			assert.Equal(t, afterAccount, abs[i].Account)
-			afters, err := store.SelectAccountBalances(afterAccount)
+			afters, err := store.SelectAccountBalances(afterAccount.ID)
 			if err != nil {
 				t.Fatal(errors.Wrapf(err, "selecting account balances for account %+v", afterAccount))
 			}
@@ -295,14 +295,4 @@ func newTestBalance(t *testing.T, time time.Time, os ...balance.Option) balance.
 	b, err := balance.New(time, os...)
 	common.FatalIfError(t, err, "creating test balance")
 	return *b
-}
-
-func newTestBalances(
-	t *testing.T, count int, start time.Time, interval time.Duration, os ...balance.Option,
-) []balance.Balance {
-	bs := make([]balance.Balance, count)
-	for i := 0; i < count; i++ {
-		bs[i] = newTestBalance(t, start.Add(time.Duration(i)*interval), os...)
-	}
-	return bs
 }

--- a/pkg/storage/storagetest/test.go
+++ b/pkg/storage/storagetest/test.go
@@ -32,7 +32,7 @@ func Test(t *testing.T, store storage.Storage) {
 		},
 		{
 			title: "update account",
-			run:   updateAccounts,
+			run:   updateAccount,
 		},
 		{
 			title: "insert and delete accounts",
@@ -185,93 +185,34 @@ func insertDeleteAndRetrieveBalances(t *testing.T, store storage.Storage) {
 	}
 }
 
-func updateAccounts(t *testing.T, store storage.Storage) {
+func updateAccount(t *testing.T, store storage.Storage) {
 	initial := accountingtest.NewAccount(t, "A", accountingtest.NewCurrencyCode(t, "YEN"), time.Now())
 
-	t.Run("valid without balances", func(t *testing.T) {
-		inserted, err := store.InsertAccount(*initial)
-		common.FatalIfError(t, err, "inserting account to store")
+	inserted, err := store.InsertAccount(*initial)
+	common.FatalIfError(t, err, "inserting account to store")
 
-		// Here we truncate to the closest second to avoid the issue where
-		// postgres stores times down to only the closest millisecond or so
-		// TODO: Sort out rounding of times logic and document it properly. For
-		// TODO: the moment, it is assumed that accounts won't be updated and
-		// TODO: then compared against their original down to such a fine grain
-		updates := accountingtest.NewAccount(t,
-			"B",
-			accountingtest.NewCurrencyCode(t, "GBP"),
-			time.Now().Truncate(time.Second),
-			account.CloseTime(time.Now().Add(24*time.Hour).Truncate(time.Second)),
-		)
+	// Here we truncate to the closest second to avoid the issue where
+	// postgres stores times down to only the closest millisecond or so
+	// TODO: Sort out rounding of times logic and document it properly. For
+	// TODO: the moment, it is assumed that accounts won't be updated and
+	// TODO: then compared against their original down to such a fine grain
+	updates := accountingtest.NewAccount(t,
+		"B",
+		accountingtest.NewCurrencyCode(t, "GBP"),
+		time.Now().Truncate(time.Second),
+		account.CloseTime(time.Now().Add(24*time.Hour).Truncate(time.Second)),
+	)
 
-		updatedA, err := store.UpdateAccount(*inserted, *updates)
-		common.FatalIfError(t, err, "updating account")
-		if !assert.NotNil(t, updatedA) {
-			t.FailNow()
-		}
-		assert.Equal(t, updatedA.ID, inserted.ID)
-		assert.True(t,
-			updatedA.Account.Equal(*updates),
-			"inserted: %+v\nupdates: %+v\nupdatedA: %+v", inserted.Account, updates, updatedA.Account,
-		)
-	})
-
-	t.Run("valid with balances", func(t *testing.T) {
-		inserted, err := store.InsertAccount(*initial)
-		common.FatalIfError(t, err, "inserting account to store")
-
-		for _, b := range newTestBalances(t, 10, inserted.Account.Opened(), time.Hour) {
-			_, err := store.InsertBalance(*inserted, b)
-			common.FatalIfError(t, err, "inserting balance")
-		}
-
-		// Here we truncate to the closest second to avoid the issue where
-		// postgres stores times down to only the closest millisecond or so
-		// TODO: Sort out rounding of times logic and document it properly. For
-		// TODO: the moment, it is assumed that accounts won't be updated and
-		// TODO: then compared against their original down to such a fine grain
-		updates := accountingtest.NewAccount(t,
-			"B",
-			accountingtest.NewCurrencyCode(t, "GBP"),
-			time.Now().Add(-time.Hour).Truncate(time.Second),
-			account.CloseTime(time.Now().Add(200*time.Hour).Truncate(time.Second)),
-		)
-
-		updatedA, err := store.UpdateAccount(*inserted, *updates)
-		common.FatalIfError(t, err, "updating account")
-		assert.Equal(t, updatedA.ID, inserted.ID)
-		assert.True(t,
-			updatedA.Account.Equal(*updates),
-			"inserted: %+v\nupdates: %+v\nupdatedA: %+v",
-			inserted.Account, updates, updatedA.Account,
-		)
-	})
-
-	t.Run("invalid with balances", func(t *testing.T) {
-		inserted, err := store.InsertAccount(*initial)
-		common.FatalIfError(t, err, "inserting account to store")
-
-		for _, b := range newTestBalances(t, 10, inserted.Account.Opened(), time.Hour) {
-			_, err := store.InsertBalance(*inserted, b)
-			common.FatalIfError(t, err, "inserting balance")
-		}
-
-		// Here we truncate to the closest second to avoid the issue where
-		// postgres stores times down to only the closest millisecond or so
-		// TODO: Sort out rounding of times logic and document it properly. For
-		// TODO: the moment, it is assumed that accounts won't be updated and
-		// TODO: then compared against their original down to such a fine grain
-		updates := accountingtest.NewAccount(t,
-			"B",
-			accountingtest.NewCurrencyCode(t, "GBP"),
-			time.Now().Add(-time.Hour).Truncate(time.Second),
-			account.CloseTime(time.Now().Add(time.Hour).Truncate(time.Second)),
-		)
-
-		updatedA, err := store.UpdateAccount(*inserted, *updates)
-		assert.Error(t, err)
-		assert.Nil(t, updatedA)
-	})
+	updatedA, err := store.UpdateAccount(inserted.ID, *updates)
+	common.FatalIfError(t, err, "updating account")
+	if !assert.NotNil(t, updatedA) {
+		t.FailNow()
+	}
+	assert.Equal(t, updatedA.ID, inserted.ID)
+	assert.True(t,
+		updatedA.Account.Equal(*updates),
+		"inserted: %+v\nupdates: %+v\nupdatedA: %+v", inserted.Account, updates, updatedA.Account,
+	)
 }
 
 func insertAndDeleteAccounts(t *testing.T, store storage.Storage) {

--- a/pkg/storage/storagetest/test.go
+++ b/pkg/storage/storagetest/test.go
@@ -204,7 +204,7 @@ func updateAccounts(t *testing.T, store storage.Storage) {
 			account.CloseTime(time.Now().Add(24*time.Hour).Truncate(time.Second)),
 		)
 
-		updatedA, err := store.UpdateAccount(inserted, updates)
+		updatedA, err := store.UpdateAccount(*inserted, *updates)
 		common.FatalIfError(t, err, "updating account")
 		if !assert.NotNil(t, updatedA) {
 			t.FailNow()
@@ -237,7 +237,7 @@ func updateAccounts(t *testing.T, store storage.Storage) {
 			account.CloseTime(time.Now().Add(200*time.Hour).Truncate(time.Second)),
 		)
 
-		updatedA, err := store.UpdateAccount(inserted, updates)
+		updatedA, err := store.UpdateAccount(*inserted, *updates)
 		common.FatalIfError(t, err, "updating account")
 		assert.Equal(t, updatedA.ID, inserted.ID)
 		assert.True(t,
@@ -268,7 +268,7 @@ func updateAccounts(t *testing.T, store storage.Storage) {
 			account.CloseTime(time.Now().Add(time.Hour).Truncate(time.Second)),
 		)
 
-		updatedA, err := store.UpdateAccount(inserted, updates)
+		updatedA, err := store.UpdateAccount(*inserted, *updates)
 		assert.Error(t, err)
 		assert.Nil(t, updatedA)
 	})

--- a/vendor/github.com/glynternet/go-accounting/account/account.go
+++ b/vendor/github.com/glynternet/go-accounting/account/account.go
@@ -106,6 +106,7 @@ func (a Account) validate() (err error) {
 // ValidateBalance first attempts to validate the Account as an entity by itself. If there are any errors with the Account, these errors are returned and the balance is not attempted to be validated against the Account.
 // If the date of the balance is outside of the TimeRange of the Account, a DateOutOfAccountTimeRange will be returned.
 func (a Account) ValidateBalance(b balance.Balance) (err error) {
+	// TODO: the account should not be validated here, only the balance should be
 	err = a.validate()
 	if err != nil {
 		return


### PR DESCRIPTION
Move UpdateAccount business logic into models package
Prior to this change, the business logic of the updating accounts, i.e.
validation etc., was witihn the storage package.

This change creates a models package which will contain the business
logic, although I am hoping that the package will be renamed at a later
stage.

The tests for storage have had to change, so the models package has some
tests, which in turn have meant that the storagetest.Storage has had to
become a little more advanced, now being a mock rather than just a stub.
This means that when there is a storage method executed with an ID for
an account, this ID 