### PR TITLE
Alter Moncli behaviour to match delta balance

### DIFF
--- a/cmd/moncli/cmd/accounts.go
+++ b/cmd/moncli/cmd/accounts.go
@@ -168,7 +168,7 @@ func prepareAccountCondition() (filter.AccountCondition, error) {
 	}
 
 	if len(notIDs) > 0 {
-		cs = append(cs, filter.Not(idsCondition(notIDs)))
+		cs = append(cs, filter.AccountNot(idsCondition(notIDs)))
 	}
 
 	if len(currencies) > 0 {

--- a/pkg/filter/account.go
+++ b/pkg/filter/account.go
@@ -23,9 +23,9 @@ func (ac AccountCondition) Filter(as storage.Accounts) storage.Accounts {
 	return filtered
 }
 
-// Not produces an AccountCondition that inverts the outcome of the given
+// AccountNot produces an AccountCondition that inverts the outcome of the given
 // AccountCondition
-func Not(c AccountCondition) AccountCondition {
+func AccountNot(c AccountCondition) AccountCondition {
 	return func(a storage.Account) bool {
 		return !c(a)
 	}

--- a/pkg/filter/account_test.go
+++ b/pkg/filter/account_test.go
@@ -164,7 +164,7 @@ func TestOpenAt(t *testing.T) {
 	}
 }
 
-func TestNot(t *testing.T) {
+func TestAccountNot(t *testing.T) {
 	var dummy storage.Account
 	for _, test := range []struct {
 		name string
@@ -183,7 +183,7 @@ func TestNot(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			f := filter.Not(stubAccountCondition(test.in))
+			f := filter.AccountNot(stubAccountCondition(test.in))
 			match := f(dummy)
 			assert.Equal(t, !test.in, match)
 		})

--- a/pkg/filter/balance.go
+++ b/pkg/filter/balance.go
@@ -10,6 +10,18 @@ import (
 // satisfies some certain condition.
 type BalanceCondition func(storage.Balance) bool
 
+// Filter returns a set of storage.Balances that have been filtered down to the
+// ones that match the BalanceCondition
+func (bc BalanceCondition) Filter(bs storage.Balances) storage.Balances {
+	var filtered storage.Balances
+	for _, b := range bs {
+		if bc(b) {
+			filtered = append(filtered, b)
+		}
+	}
+	return filtered
+}
+
 // After produces a BalanceCondition that can be used to identify if an
 // is from after a given time.
 func After(t time.Time) BalanceCondition {

--- a/pkg/filter/balance.go
+++ b/pkg/filter/balance.go
@@ -1,0 +1,19 @@
+package filter
+
+import (
+	"time"
+
+	"github.com/glynternet/mon/pkg/storage"
+)
+
+// BalanceCondition is a function that will return true if a given storage.Balance
+// satisfies some certain condition.
+type BalanceCondition func(storage.Balance) bool
+
+// After produces a BalanceCondition that can be used to identify if an
+// is from after a given time.
+func After(t time.Time) BalanceCondition {
+	return func(a storage.Balance) bool {
+		return a.Date.After(t)
+	}
+}

--- a/pkg/filter/balance.go
+++ b/pkg/filter/balance.go
@@ -22,6 +22,14 @@ func (bc BalanceCondition) Filter(bs storage.Balances) storage.Balances {
 	return filtered
 }
 
+// BalanceNot produces a BalanceCondition that inverts the outcome of the given
+// BalanceCondition
+func BalanceNot(c BalanceCondition) BalanceCondition {
+	return func(a storage.Balance) bool {
+		return !c(a)
+	}
+}
+
 // After produces a BalanceCondition that can be used to identify if an
 // is from after a given time.
 func After(t time.Time) BalanceCondition {

--- a/pkg/filter/balance.go
+++ b/pkg/filter/balance.go
@@ -30,9 +30,9 @@ func BalanceNot(c BalanceCondition) BalanceCondition {
 	}
 }
 
-// After produces a BalanceCondition that can be used to identify if an
-// is from after a given time.
-func After(t time.Time) BalanceCondition {
+// BalanceAfter produces a BalanceCondition that can be used to identify if a
+// Balance is from after a given time.
+func BalanceAfter(t time.Time) BalanceCondition {
 	return func(a storage.Balance) bool {
 		return a.Date.After(t)
 	}

--- a/pkg/filter/balance_test.go
+++ b/pkg/filter/balance_test.go
@@ -66,7 +66,7 @@ func TestAfter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			match := filter.After(tt.Time)(b)
+			match := filter.BalanceAfter(tt.Time)(b)
 			assert.Equal(t, tt.match, match)
 		})
 	}
@@ -74,7 +74,7 @@ func TestAfter(t *testing.T) {
 
 func TestBalanceCondition_Filter(t *testing.T) {
 	date := time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
-	c := filter.After(date)
+	c := filter.BalanceAfter(date)
 	for _, test := range []struct {
 		name string
 		in   storage.Balances

--- a/pkg/filter/balance_test.go
+++ b/pkg/filter/balance_test.go
@@ -1,0 +1,40 @@
+package filter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/glynternet/go-accounting/balance"
+	"github.com/glynternet/mon/pkg/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAfter(t *testing.T) {
+	b := storage.Balance{
+		Balance: balance.Balance{
+			Date: time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC),
+		},
+	}
+
+	tests := []struct {
+		name string
+		time.Time
+		match bool
+	}{
+		{
+			name:  "after",
+			match: true,
+			Time:  time.Date(1000, 1, 1, 1, 1, 1, 1, time.UTC),
+		},
+		{
+			name: "not after",
+			Time: time.Date(3000, 1, 1, 1, 1, 1, 1, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match := After(tt.Time)(b)
+			assert.Equal(t, tt.match, match)
+		})
+	}
+}

--- a/pkg/filter/balance_test.go
+++ b/pkg/filter/balance_test.go
@@ -10,6 +10,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func stubBalanceCondition(match bool) filter.BalanceCondition {
+	return func(_ storage.Balance) bool {
+		return match
+	}
+}
+
+func TestBalanceNot(t *testing.T) {
+	var dummy storage.Balance
+	for _, test := range []struct {
+		name string
+		in   bool
+	}{
+		{
+			name: "zero-values",
+		},
+		{
+			name: "inner filter match",
+			in:   true,
+		},
+		{
+			name: "inner filter non-match",
+			in:   false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := filter.BalanceNot(stubBalanceCondition(test.in))
+			match := f(dummy)
+			assert.Equal(t, !test.in, match)
+		})
+	}
+}
+
 func TestAfter(t *testing.T) {
 	b := storage.Balance{
 		Balance: balance.Balance{


### PR DESCRIPTION
Prior to these changes, the behaviour of moncli would assume that the balances given to it for a given account were a chronologic list of absolute values.

This change makes moncli behave as the balances are each a delta balance, where to calculate the total value at any given time, you must sum the delta balances which occurred before the time in question.