### PR TITLE
Show date of latest balance in accounts balances cmd

### DIFF
--- a/cmd/moncli/cmd/account.go
+++ b/cmd/moncli/cmd/account.go
@@ -442,27 +442,26 @@ var accountBalanceCmd = &cobra.Command{
 			t = *balanceDate.Time
 		}
 
-		b, err := accountBalanceAtTime(c, *a, t)
+		bs, err := accountBalancesAtTime(c, *a, t)
 		if err != nil {
 			return errors.Wrapf(err, "getting balance at time:%+v for account:%+v", t, a)
 		}
-		fmt.Println(b.Amount)
+		fmt.Println(bs.InnerBalances().Sum())
 		return nil
 	},
 }
 
-func accountBalanceAtTime(store storage.Storage, a storage.Account, at time.Time) (balance.Balance, error) {
+// accountBalancesAtTime retrieves the balances that existed for the account at
+// a given time.
+func accountBalancesAtTime(store storage.Storage, a storage.Account, at time.Time) (storage.Balances, error) {
 	bs, err := store.SelectAccountBalances(a.ID)
 	if err != nil {
-		return balance.Balance{}, errors.Wrapf(err, "selecting balances for account: %+v", a)
+		return storage.Balances{}, errors.Wrapf(err, "selecting balances for account: %+v", a)
 	}
 	c := filter.BalanceNot(filter.BalanceAfter(at))
 	filtered := c.Filter(*bs)
 
-	return balance.Balance{
-		Date:   at,
-		Amount: filtered.InnerBalances().Sum(),
-	}, nil
+	return filtered, err
 }
 
 func init() {

--- a/cmd/moncli/cmd/accounts.go
+++ b/cmd/moncli/cmd/accounts.go
@@ -124,14 +124,20 @@ func accounts(store storage.Storage) (storage.Accounts, error) {
 func accountsBalances(s storage.Storage, as storage.Accounts, at time.Time) ([]accountbalance.AccountBalance, error) {
 	var abs []accountbalance.AccountBalance
 	for _, a := range as {
-		b, err := accountBalanceAtTime(s, a, at)
+		bs, err := accountBalancesAtTime(s, a, at)
 		if err != nil {
-			log.Println(errors.Wrapf(err, "getting balance at time:%+v for account:%+v", at, a))
-			continue
+			return nil, errors.Wrapf(err, "getting balances at time:%+v for account:%+v", at, a)
+		}
+		l, err := bs.InnerBalances().Latest()
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting latest balance for account:%+v balances:%+v", a, bs)
 		}
 		abs = append(abs, accountbalance.AccountBalance{
 			Account: a,
-			Balance: b,
+			Balance: balance.Balance{
+				Date:   l.Date,
+				Amount: bs.InnerBalances().Sum(),
+			},
 		})
 	}
 


### PR DESCRIPTION
When the model of the data was changed to be delta balances instead of
absolute balances, the logic of moncli was altered, including showing
the date of the query in the "latest balance" column, rather than the
date of the latest balance that contributes to the account total.

This change alters the code to show the date of the latest balance that
contributed to the total.

The signature of accountBalanceAtTime(storage.Storage,
storage.Account,time.Time) (balance.Balance, error)
has been changed to accountBalancesAtTime(store storage.Storage,
a storage.Account, at time.Time) (storage.Balances, error)
so that it is more reusable, with less responsibility.