### PR TITLE
Sort balances by date and then by balance id

### DIFF
--- a/pkg/storage/postgres/balance.go
+++ b/pkg/storage/postgres/balance.go
@@ -35,7 +35,7 @@ var (
 		balancesSelectPrefix,
 		balancesFieldAccountID,
 		balancesFieldTime,
-		balancesFieldAccountID)
+		balancesFieldID)
 
 	balancesInsertFields = fmt.Sprintf(
 		"%s, %s, %s",


### PR DESCRIPTION
Prior to this change, the query for balances would sort the returned
balancesquery by balance date and then account_id instead of id of the
balance.

This change alters the sorting to be by date/time and then by id, of the
balance.