### PR TITLE
use http.Handler over appJSONHandler for resusability

### DIFF
--- a/internal/router/logger.go
+++ b/internal/router/logger.go
@@ -7,7 +7,7 @@ import (
 )
 
 // logger returns a simple logger that wraps a http.handler and logs any incoming request
-func logger(inner appJSONHandler, name string) http.Handler {
+func logger(inner http.Handler, name string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 


### PR DESCRIPTION
Prior to this commit, the signature of the logger middleware took an
appJSONHandler.

This commit changes the signature to accept a http.Handler interface,
which the appJSONHandler interface satisfies, increasing the reusability
of the function.