### PR TITLE
authmiddleware: Simple auth middleware

### DIFF
--- a/internal/router/authoriser.go
+++ b/internal/router/authoriser.go
@@ -1,0 +1,28 @@
+package router
+
+import (
+	"log"
+	"net/http"
+)
+
+// WithAuthoriser wraps a handler with the given RequestAuthoriser.
+// When handling requests, if the request is not authorised, the next
+// http.Handler is not called.
+func WithAuthoriser(logger *log.Logger, ra RequestAuthoriser, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := ra.Authorise(r)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			if logger != nil {
+				logger.Printf("Unauthorised request: %+v", err)
+			}
+			return
+		}
+		next.ServeHTTP(w, r)
+	}
+}
+
+// RequestAuthoriser returns an error of the request is not authorised.
+type RequestAuthoriser interface {
+	Authorise(*http.Request) error
+}

--- a/internal/router/authoriser_test.go
+++ b/internal/router/authoriser_test.go
@@ -1,0 +1,68 @@
+package router_test
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/glynternet/mon/internal/router"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockRequestAuthoriser struct {
+	err     error
+	request *http.Request
+}
+
+func (ra *mockRequestAuthoriser) Authorise(r *http.Request) error {
+	ra.request = r
+	return ra.err
+}
+
+type mockHandler struct {
+	request *http.Request
+	writer  http.ResponseWriter
+}
+
+func (h *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.writer = w
+	h.request = r
+}
+
+func TestWithAuthoriser(t *testing.T) {
+	t.Run("unauthorised", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.New(&buf, "", 0)
+		var next mockHandler
+		ra := mockRequestAuthoriser{err: errors.New("auth error")}
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "http://any/", nil)
+
+		hf := router.WithAuthoriser(logger, &ra, &next)
+		hf(w, r)
+		assert.Equal(t, r, ra.request)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Equal(t, "Unauthorised request: auth error\n", buf.String())
+		assert.Nil(t, next.writer)
+		assert.Nil(t, next.request)
+	})
+
+	t.Run("authorised", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.New(&buf, "", 0)
+		var ra mockRequestAuthoriser
+		next := mockHandler{}
+		hf := router.WithAuthoriser(logger, &ra, &next)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "http://any/", nil)
+		hf(w, r)
+		assert.Equal(t, w, next.writer)
+		assert.Equal(t, r, next.request)
+		assert.Empty(t, buf)
+	})
+}


### PR DESCRIPTION
This commit adds a simple reusable request authorisation
middleware, that rejects any requests with unauthorised requests
with a 401.