### PR TITLE
bug-appHandlerStatus: write status to response

### DIFF
--- a/internal/router/apphandler.go
+++ b/internal/router/apphandler.go
@@ -51,6 +51,7 @@ func (ah appJSONHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.WriteHeader(status)
 	w.Header().Set(`Content-Type`, `application/json; charset=UTF-8`)
 	_, wErr := w.Write(bs)
 	if wErr != nil {


### PR DESCRIPTION
Prior to this commit, the response was never written to the status when
an appHandler would ServeHTTP.

This would cause the status to always be 200

This change fixes this issue.