### PR TITLE
Define BINARIES variables in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ GOBUILD_CMD ?= $(GOBUILD_ENVVARS) go build $(GOBUILD_FLAGS)
 OS ?= linux
 ARCH ?= amd64
 
-build: moncli monserve
+BINARIES ?= monauth moncli monserve
+
+build: $(BINARIES)
 
 clean:
 	rm $(BUILD_DIR)/*


### PR DESCRIPTION
This way, there is a single source of truth for all of the binaries.

In the future, adding another binary should just mean adding a
value to the variable