### PR TITLE
fix: don't select account when selecting balance

### DIFF
--- a/cmd/moncli/cmd/balance.go
+++ b/cmd/moncli/cmd/balance.go
@@ -33,11 +33,6 @@ var balanceSelectCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrap(err, "selecting balance")
 		}
-		a, err := c.SelectAccount(b.ID)
-		if err != nil {
-			return errors.Wrapf(err, "selecting account for balance %+v", b)
-		}
-		table.Accounts(storage.Accounts{*a}, os.Stdout)
 		table.Balances(storage.Balances{*b}, os.Stdout)
 		return nil
 	},
@@ -60,11 +55,6 @@ var balanceDeleteCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrap(err, "selecting balance")
 		}
-		a, err := c.SelectAccount(b.ID)
-		if err != nil {
-			return errors.Wrapf(err, "selecting account for balance %+v", b)
-		}
-		table.Accounts(storage.Accounts{*a}, os.Stdout)
 		table.Balances(storage.Balances{*b}, os.Stdout)
 		return c.DeleteBalance(uint(id))
 	},


### PR DESCRIPTION
Prior to this commit, `moncli` would try to select the account
associated with a selected balance, but this is not possible because the
balance doesn't have the id of the account. The id of the balance was
incorrectly used, instead.