### PR TITLE
Add parser for just month and date to date flag

### DIFF
--- a/pkg/date/flag.go
+++ b/pkg/date/flag.go
@@ -9,9 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	longDateFormat = "2006-1-2"
-)
+const longDateFormat = "2006-1-2"
 
 type flag struct {
 	*time.Time

--- a/pkg/date/flag.go
+++ b/pkg/date/flag.go
@@ -9,7 +9,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-const dateFormat = "2006-1-2"
+const (
+	longDateFormat = "2006-1-2"
+)
 
 type flag struct {
 	*time.Time
@@ -26,7 +28,7 @@ func (f flag) String() string {
 	if f.Time == nil {
 		return ""
 	}
-	return f.Time.Format(dateFormat)
+	return f.Time.Format(longDateFormat)
 }
 
 // Type returns the string that represents the type of flag.
@@ -49,7 +51,7 @@ func (f *flag) Set(value string) error {
 	for _, parse := range []func(string) (time.Time, error){
 		parseYesterday,
 		parseRelative,
-		format(dateFormat).parse,
+		format(longDateFormat).parse,
 	} {
 		d, err := parse(val)
 		if err == nil {

--- a/pkg/date/flag_test.go
+++ b/pkg/date/flag_test.go
@@ -45,14 +45,14 @@ func TestFlag_SetErrors(t *testing.T) {
 	}
 }
 
-func TestFlag_SetExplicit(t *testing.T) {
+func TestFlag_SetLongFormat(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		vals []string
 		time.Time
 	}{
 		{
-			name: "valid explicit",
+			name: "valid long format",
 			vals: []string{"2018-03-02", "2018-3-2"},
 			Time: time.Date(2018, 03, 02, 0, 0, 0, 0, time.UTC),
 		},

--- a/pkg/date/flag_test.go
+++ b/pkg/date/flag_test.go
@@ -27,7 +27,7 @@ func TestFlag_SetErrors(t *testing.T) {
 		},
 		{
 			name: "invalid date format",
-			vals: []string{"02/03", "-1000-01-87", "03-02"},
+			vals: []string{"02/03", "-1000-01-87"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -55,6 +55,36 @@ func TestFlag_SetLongFormat(t *testing.T) {
 			name: "valid long format",
 			vals: []string{"2018-03-02", "2018-3-2"},
 			Time: time.Date(2018, 03, 02, 0, 0, 0, 0, time.UTC),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for key, val := range test.vals {
+				k := key
+				v := val
+				t.Run(fmt.Sprintf("%d-%s", k, val), func(t *testing.T) {
+					f := &flag{}
+					err := f.Set(v)
+					assert.NoError(t, err)
+					if assert.NotNil(t, f) &&
+						assert.NotNil(t, *f.Time) {
+						assert.Equal(t, test.Time, *f.Time)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestFlag_SetMonthDate(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		vals []string
+		time.Time
+	}{
+		{
+			name: "valid month date",
+			vals: []string{"03-02", "3-2"},
+			Time: time.Date(time.Now().Year(), 03, 02, 0, 0, 0, 0, time.UTC),
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/date/flag_test.go
+++ b/pkg/date/flag_test.go
@@ -65,8 +65,10 @@ func TestFlag_SetLongFormat(t *testing.T) {
 					f := &flag{}
 					err := f.Set(v)
 					assert.NoError(t, err)
-					assert.NotNil(t, f)
-					assert.Equal(t, test.Time, *f.Time)
+					if assert.NotNil(t, f) &&
+						assert.NotNil(t, *f.Time) {
+						assert.Equal(t, test.Time, *f.Time)
+					}
 				})
 			}
 		})


### PR DESCRIPTION
Prior to this change, only explicit date values that could be parsed by the date flag were in the form yyyy-mm-dd.

This change introduces a parser which can parse mm-dd, for convenience.